### PR TITLE
fix: remove `vue-template-compiler` as dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
     "globby": "^11.0.3",
     "jiti": "^1.10.1",
     "mri": "^1.1.6",
-    "upath": "^2.0.1",
-    "vue-template-compiler": "^2.6.14"
+    "upath": "^2.0.1"
   },
   "devDependencies": {
     "@nuxtjs/eslint-config-typescript": "latest",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4993,7 +4993,7 @@ vue-eslint-parser@^7.6.0:
     esquery "^1.4.0"
     lodash "^4.17.15"
 
-vue-template-compiler@^2.6.12, vue-template-compiler@^2.6.14:
+vue-template-compiler@^2.6.12:
   version "2.6.14"
   resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.6.14.tgz#a2f0e7d985670d42c9c9ee0d044fed7690f4f763"
   integrity sha512-ODQS1SyMbjKoO1JBJZojSw6FE4qnh9rIpUZn2EUT86FKizx9uH5z6uXiIrm4/Nb/gwxTi/o17ZDEGWAXHvtC7g==


### PR DESCRIPTION
Probably sneaked in by accident 😜. Blocking https://github.com/nuxt/framework/pull/1285 https://github.com/nuxt/framework/pull/1180