### PR TITLE
critical-fix: multiline regex for exports

### DIFF
--- a/src/make.ts
+++ b/src/make.ts
@@ -86,7 +86,7 @@ export async function mkdist (options: MkdistOptions /* istanbul ignore next */ 
   for (const output of outputs.filter(o => o.extension === '.mjs')) {
     // Resolve import statements
     output.contents = output.contents!.replace(
-      /(import|export)([\s\S]*?)['"](.*)(['"])/g,
+      /(import|export)([\s\S]*?)\s?from\s?['"](.*)(['"])/g,
       (_, type, head, id, tail) => type + head + resolveId(output.path, id) + tail
     )
   }


### PR DESCRIPTION
oop! thanks for merging the last PR, but I actually broke things (very sorry)... Should add a test. The regex in #17 matches `export <anything> ""`. which incidentally matches actual exports that contain strings.
```javascript
export const hi = "";

export class Hello {
  constructor() {
    this.hi = "" <- matched!
  }
}
```

I'm very sorry. This PR adds back the `from` in the regex, but also keeps the multi-line matching.

- before: https://regex101.com/r/iJciCA/1
- after: https://regex101.com/r/ukpG5C/1
