### PR TITLE
feat: support filtering input files with pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ While there are tools like [tsc](https://www.typescriptlang.org/docs/handbook/co
 ## 🚀 Usage
 
 ```bash
-npx mkdist [rootDir] [--src=src] [--dist=dist] [--format=cjs|esm] [-d|--declaration] [--ext=mjs|js|ts]
+npx mkdist [rootDir] [--src=src] [--dist=dist] [--pattern=glob] [--format=cjs|esm] [-d|--declaration] [--ext=mjs|js|ts]
 ```
 
 ## License

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,7 +6,7 @@ async function main () {
 
   if (args.help) {
     // eslint-disable-next-line no-console
-    console.log('Usage: npx mkdist [rootDir] [--src=src] [--dist=dist] [--format=cjs|esm] [-d|--declaration] [--ext=mjs|js|ts]')
+    console.log('Usage: npx mkdist [rootDir] [--src=src] [--dist=dist] [--pattern=glob] [--format=cjs|esm] [-d|--declaration] [--ext=mjs|js|ts]')
     process.exit(0)
   }
 
@@ -15,6 +15,7 @@ async function main () {
     srcDir: args.src,
     distDir: args.dist,
     format: args.format,
+    pattern: args.pattern,
     ext: args.ext,
     declaration: Boolean(args.declaration || args.d)
   })

--- a/src/make.ts
+++ b/src/make.ts
@@ -7,6 +7,7 @@ import { getDeclarations } from './utils/dts'
 export interface MkdistOptions extends LoaderOptions {
   rootDir?: string
   srcDir?: string
+  pattern?: string
   distDir?: string
   cleanDist?: boolean
 }
@@ -25,7 +26,7 @@ export async function mkdist (options: MkdistOptions /* istanbul ignore next */ 
   }
 
   // Scan input files
-  const filePaths = await globby('**', { absolute: false, cwd: options.srcDir })
+  const filePaths = await globby(options.pattern || '**', { absolute: false, cwd: options.srcDir })
   const files: InputFile[] = filePaths.map((path) => {
     const srcPath = resolve(options.srcDir!, path)
     return {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -22,6 +22,17 @@ describe('mkdist', () => {
     ].map(f => resolve(rootDir, f)).sort())
   })
 
+  it('mkdist (custom glob pattern)', async () => {
+    const rootDir = resolve(__dirname, 'fixture')
+    const { writtenFiles } = await mkdist({ rootDir, pattern: 'components/**' })
+    expect(writtenFiles.sort()).toEqual([
+      'dist/components/blank.vue',
+      'dist/components/js.vue',
+      'dist/components/script-setup-ts.vue',
+      'dist/components/ts.vue'
+    ].map(f => resolve(rootDir, f)).sort())
+  })
+
   it('mkdist (emit types)', async () => {
     const rootDir = resolve(__dirname, 'fixture')
     const { writtenFiles } = await mkdist({ rootDir, declaration: true })


### PR DESCRIPTION
Related to #18.

This PR adds a new `pattern` option to filter input files. 

The option can be specified in the CLI via the `--pattern` argument. 