### PR TITLE
fix: .d.mts extension for .mjs files

### DIFF
--- a/src/utils/dts.ts
+++ b/src/utils/dts.ts
@@ -27,7 +27,7 @@ export async function getDeclarations (vfs: Map<string, string>) {
   const output: Record<string, string> = {}
 
   for (const filename of inputFiles) {
-    const dtsFilename = filename.replace(/\.(ts|js)$/, '.d.ts')
+    const dtsFilename = filename.replace(/\.(m|c)?(ts|js)$/, '.d.$1ts')
     output[filename] = vfs.get(dtsFilename) || ''
   }
 


### PR DESCRIPTION
Hello, this is a fix to deal with declaration files of .cjs or .mjs files.

Presently, you can build using the `.mjs` extension and it works fine, but if you choose to emit declaration files too they will be emitted with the usual `.d.ts` extension. The issue is that Typescript expects the declaration file of a `.mjs` file to be `.d.mts`.

Official documentation is here: https://www.typescriptlang.org/docs/handbook/esm-node.html