### PR TITLE
fix: support emitting `.d.mts` for `.mjs` files

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "siroc": "latest",
     "standard-version": "latest",
     "ts-jest": "latest",
-    "typescript": "latest"
+    "typescript": "^4.5.5"
   },
   "peerDependencies": {
     "typescript": ">=3.7"

--- a/src/loaders/js.ts
+++ b/src/loaders/js.ts
@@ -3,8 +3,11 @@ import jiti from 'jiti'
 
 import type { Loader, LoaderResult } from '../loader'
 
+const DECLARATION_RE = /\.d\.[cm]?ts$/
+const CM_LETTER_RE = /(?<=\.)(c|m)(?=[tj]s$)/
+
 export const jsLoader: Loader = async (input, { options }) => {
-  if (!['.ts', '.js', '.mjs'].includes(input.extension) || input.path.endsWith('.d.ts')) {
+  if (!['.ts', '.js', '.cjs', '.mjs'].includes(input.extension) || input.path.match(DECLARATION_RE)) {
     return
   }
 
@@ -13,12 +16,14 @@ export const jsLoader: Loader = async (input, { options }) => {
   let contents = await input.getContents()
 
   // declaration
-  if (options.declaration && !input.srcPath?.endsWith('.d.ts')) {
+  if (options.declaration && !input.srcPath?.match(DECLARATION_RE)) {
+    const cm = input.srcPath?.match(CM_LETTER_RE)?.[0] || ''
+    const extension = `.d.${cm}ts`
     output.push({
       contents,
       srcPath: input.srcPath,
       path: input.path,
-      extension: '.d.ts',
+      extension,
       declaration: true
     })
   }

--- a/src/utils/dts.ts
+++ b/src/utils/dts.ts
@@ -27,7 +27,7 @@ export async function getDeclarations (vfs: Map<string, string>) {
   const output: Record<string, string> = {}
 
   for (const filename of inputFiles) {
-    const dtsFilename = filename.replace(/\.(ts|js)$/, '.d.ts')
+    const dtsFilename = filename.replace(/\.(m|c)?(ts|js)$/, '.d.$1ts')
     output[filename] = vfs.get(dtsFilename) || ''
   }
 

--- a/test/fixture/src/bar/esm.mjs
+++ b/test/fixture/src/bar/esm.mjs
@@ -1,0 +1,1 @@
+export default 'esm'

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -18,7 +18,8 @@ describe('mkdist', () => {
       'dist/components/js.vue',
       'dist/components/script-setup-ts.vue',
       'dist/components/ts.vue',
-      'dist/bar/index.mjs'
+      'dist/bar/index.mjs',
+      'dist/bar/esm.mjs'
     ].map(f => resolve(rootDir, f)).sort())
   })
 
@@ -50,10 +51,13 @@ describe('mkdist', () => {
       'dist/components/ts.vue',
       'dist/components/ts.vue.d.ts',
       'dist/bar/index.mjs',
-      'dist/bar/index.d.ts'
+      'dist/bar/index.d.ts',
+      'dist/bar/esm.mjs',
+      'dist/bar/esm.d.mts'
     ].map(f => resolve(rootDir, f)).sort())
 
     expect(await readFile(resolve(rootDir, 'dist/foo.d.ts'), 'utf8')).toMatch('manual declaration')
+    expect(await readFile(resolve(rootDir, 'dist/bar/esm.d.mts'), 'utf8')).toMatch('declare')
   }, 50000)
 })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4800,10 +4800,15 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.3.5, typescript@latest:
+typescript@^4.3.5:
   version "4.4.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
   integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
+
+typescript@^4.5.5:
+  version "4.5.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
+  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
 
 uglify-js@^3.1.4:
   version "3.14.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4800,12 +4800,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.3.5:
-  version "4.4.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
-  integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
-
-typescript@^4.5.5:
+typescript@^4.3.5, typescript@^4.5.5:
   version "4.5.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
   integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==


### PR DESCRIPTION
includes #23, but with a few further fixes

resolves #25