### PR TITLE
feat: support multiple glob patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ While there are tools like [tsc](https://www.typescriptlang.org/docs/handbook/co
 ## 🚀 Usage
 
 ```bash
-npx mkdist [rootDir] [--src=src] [--dist=dist] [--pattern=glob] [--format=cjs|esm] [-d|--declaration] [--ext=mjs|js|ts]
+npx mkdist [rootDir] [--src=src] [--dist=dist] [--pattern=glob [--pattern=more-glob]] [--format=cjs|esm] [-d|--declaration] [--ext=mjs|js|ts]
 ```
 
 ## License

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,7 +6,7 @@ async function main () {
 
   if (args.help) {
     // eslint-disable-next-line no-console
-    console.log('Usage: npx mkdist [rootDir] [--src=src] [--dist=dist] [--pattern=glob] [--format=cjs|esm] [-d|--declaration] [--ext=mjs|js|ts]')
+    console.log('Usage: npx mkdist [rootDir] [--src=src] [--dist=dist] [--pattern=glob [--pattern=more-glob]] [--format=cjs|esm] [-d|--declaration] [--ext=mjs|js|ts]')
     process.exit(0)
   }
 

--- a/src/make.ts
+++ b/src/make.ts
@@ -7,7 +7,7 @@ import { getDeclarations } from './utils/dts'
 export interface MkdistOptions extends LoaderOptions {
   rootDir?: string
   srcDir?: string
-  pattern?: string
+  pattern?: string | string[]
   distDir?: string
   cleanDist?: boolean
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -34,6 +34,16 @@ describe('mkdist', () => {
     ].map(f => resolve(rootDir, f)).sort())
   })
 
+  it('mkdist (multiple glob patterns)', async () => {
+    const rootDir = resolve(__dirname, 'fixture')
+    const { writtenFiles } = await mkdist({ rootDir, pattern: ['components/**', '!components/js.vue'] })
+    expect(writtenFiles.sort()).toEqual([
+      'dist/components/blank.vue',
+      'dist/components/script-setup-ts.vue',
+      'dist/components/ts.vue'
+    ].map(f => resolve(rootDir, f)).sort())
+  })
+
   it('mkdist (emit types)', async () => {
     const rootDir = resolve(__dirname, 'fixture')
     const { writtenFiles } = await mkdist({ rootDir, declaration: true })


### PR DESCRIPTION
This PR iterates over #21. 

The `globby` library supports an array with multiple globs as its first argument, and `mri` already supports multiple inputs for a flag (`--pattern=aaa --pattern=bbb --> pattern: ['aaa', 'bbb']`). 

Adding the ability to pass multiple patterns makes it easier to use negative patterns and create more complex filters. 

On the documentation, I am not sure whether the `[--pattern=glob [--pattern=more-glob]]` signature is correct or if there is a clearer way to express the feature.