### PR TITLE
feat: add array type for pattern and copyFile in stream

### DIFF
--- a/src/make.ts
+++ b/src/make.ts
@@ -7,7 +7,7 @@ import { getDeclarations } from './utils/dts'
 export interface MkdistOptions extends LoaderOptions {
   rootDir?: string
   srcDir?: string
-  pattern?: string
+  pattern?: string | readonly string[]
   distDir?: string
   cleanDist?: boolean
 }

--- a/src/make.ts
+++ b/src/make.ts
@@ -1,6 +1,7 @@
 import globby from 'globby'
 import { resolve, extname, join, basename, dirname } from 'pathe'
-import { emptyDir, mkdirp, copyFile, readFile, writeFile, unlink } from 'fs-extra'
+import { emptyDir, mkdirp, readFile, writeFile, unlink } from 'fs-extra'
+import { copyFileInStream } from './stream'
 import { InputFile, LoaderOptions, createLoader, OutputFile } from './loader'
 import { getDeclarations } from './utils/dts'
 
@@ -98,7 +99,7 @@ export async function mkdist (options: MkdistOptions /* istanbul ignore next */ 
     const outFile = join(options.distDir!, output.path)
     await mkdirp(dirname(outFile))
     if (output.raw) {
-      await copyFile(output.srcPath!, outFile)
+      await copyFileInStream(output.srcPath!, outFile)
     } else {
       await writeFile(outFile, output.contents, 'utf8')
     }

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1,0 +1,9 @@
+import { pipeline } from 'stream/promises'
+import { createReadStream, createWriteStream } from 'fs'
+
+export const copyFileInStream = (srcPath: string, outPath: string) => {
+  const srcStream = createReadStream(srcPath)
+  const outStream = createWriteStream(outPath, { encoding: 'utf-8' })
+
+  return pipeline(srcStream, outStream)
+}


### PR DESCRIPTION
👀 The [Globby](https://github.com/sindresorhus/globby) supports `string[]`，and using streams for copy can support large files