### PR TITLE
fix: ensure sass output file has css extension

### DIFF
--- a/src/loaders/sass.ts
+++ b/src/loaders/sass.ts
@@ -1,6 +1,6 @@
 import type { Loader, LoaderResult } from "../loader";
 
-export const sassLoader: Loader = async (input, { options }) => {
+export const sassLoader: Loader = async (input) => {
   if (![".sass", ".scss"].includes(input.extension)) {
     return;
   }
@@ -14,7 +14,7 @@ export const sassLoader: Loader = async (input, { options }) => {
   output.push({
     contents: compileString(contents).css,
     path: input.path,
-    extension: `.${options.ext || "css"}`
+    extension: ".css"
   });
 
   return output;

--- a/test/fixture/src/demo.scss
+++ b/test/fixture/src/demo.scss
@@ -1,0 +1,5 @@
+$color: green;
+
+.test {
+  color: $color;
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -11,6 +11,7 @@ describe("mkdist", () => {
     const { writtenFiles } = await mkdist({ rootDir });
     expect(writtenFiles.sort()).toEqual([
       "dist/README.md",
+      "dist/demo.css",
       "dist/foo.mjs",
       "dist/foo.d.ts", // manual
       "dist/index.mjs",
@@ -50,6 +51,7 @@ describe("mkdist", () => {
     const { writtenFiles } = await mkdist({ rootDir, declaration: true });
     expect(writtenFiles.sort()).toEqual([
       "dist/README.md",
+      "dist/demo.css",
       "dist/foo.mjs",
       "dist/foo.d.ts",
       "dist/index.mjs",
@@ -70,6 +72,14 @@ describe("mkdist", () => {
     expect(await readFile(resolve(rootDir, "dist/foo.d.ts"), "utf8")).toMatch("manual declaration");
     expect(await readFile(resolve(rootDir, "dist/bar/esm.d.mts"), "utf8")).toMatch("declare");
   }, 50_000);
+
+  it("mkdist (sass compilation)", async () => {
+    const rootDir = resolve(__dirname, "fixture");
+    await mkdist({ rootDir });
+    const css = await readFile(resolve(rootDir, "dist/demo.css"), "utf8");
+
+    expect(css).toMatch("color: green");
+  });
 });
 
 describe("createLoader", () => {


### PR DESCRIPTION
This PR should fix https://github.com/nuxt/module-builder/issues/67 by forcing sass input files to be always outputted with a `.css` extension.

The code has been extracted from https://github.com/unjs/mkdist/pull/109 for easier review. 