### PR TITLE
fix: add support for multi-line import extension normalization

### DIFF
--- a/src/make.ts
+++ b/src/make.ts
@@ -96,7 +96,7 @@ export async function mkdist(
   for (const output of outputs.filter((o) => o.extension === ".mjs")) {
     // Resolve import statements
     output.contents = output.contents.replace(
-      /(import|export)(.* from ["'])(.*)(["'])/g,
+      /(import|export)(\s+(?:.+|{[\s\w,]+})\s+from\s+["'])(.*)(["'])/g,
       (_, type, head, id, tail) =>
         type + head + resolveId(output.path, id, esmResolveExtensions) + tail
     );


### PR DESCRIPTION
Fixes #45 and https://github.com/unjs/unbuild/issues/83.

The change essentially does the following:
- One-line imports are handled as they were before
- Multi-line imports are handled only if brackets are present, allowing full control over the multi-line capture group, so that we don't mistakenly capture functions and objects that use brackets.

The simplest solution of using `[\s\S]` instead of `.*` will spill over to `export function() {}` and `export {};`, therefore it's not feasible.