### PR TITLE
feat: add support for relativising type exports

### DIFF
--- a/src/make.ts
+++ b/src/make.ts
@@ -97,8 +97,17 @@ export async function mkdist(
     }
     return id;
   };
-  const esmResolveExtensions = ["", "/index.mjs", "/index.js", ".mjs", ".ts"];
-  for (const output of outputs.filter((o) => o.extension === ".mjs")) {
+  const esmResolveExtensions = [
+    "",
+    "/index.mjs",
+    "/index.js",
+    ".mjs",
+    ".ts",
+    ".js",
+  ];
+  for (const output of outputs.filter(
+    (o) => o.extension === ".mjs" || o.extension === ".js"
+  )) {
     // Resolve import statements
     output.contents = output.contents.replace(
       /(import|export)(\s+(?:.+|{[\s\w,]+})\s+from\s+["'])(.*)(["'])/g,


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/unjs/mkdist/issues/137
related: https://github.com/nuxt/nuxt/issues/19689

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Our regexp already guards against replacing in CJS files, and we already resolve `.js` files within esm, so I think this is a safe change to make.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
