### PR TITLE
feat: allow passing esbuild transform options

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -1,4 +1,4 @@
-import type { TransformOptions } from "esbuild";
+import type { CommonOptions } from "esbuild";
 import { vueLoader, jsLoader, sassLoader } from "./loaders";
 
 export interface InputFile {
@@ -31,7 +31,7 @@ export interface LoaderOptions {
   ext?: "mjs" | "js" | "ts";
   format?: "cjs" | "esm";
   declaration?: boolean;
-  esbuild?: TransformOptions;
+  esbuild?: CommonOptions;
 }
 
 export interface LoaderContext {

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -31,7 +31,7 @@ export interface LoaderOptions {
   ext?: "mjs" | "js" | "ts";
   format?: "cjs" | "esm";
   declaration?: boolean;
-  esbuildOptions?: TransformOptions;
+  esbuild?: TransformOptions;
 }
 
 export interface LoaderContext {

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -1,3 +1,4 @@
+import type { TransformOptions } from "esbuild";
 import { vueLoader, jsLoader, sassLoader } from "./loaders";
 
 export interface InputFile {
@@ -30,6 +31,7 @@ export interface LoaderOptions {
   ext?: "mjs" | "js" | "ts";
   format?: "cjs" | "esm";
   declaration?: boolean;
+  esbuildOptions?: TransformOptions;
 }
 
 export interface LoaderContext {

--- a/src/loaders/js.ts
+++ b/src/loaders/js.ts
@@ -42,8 +42,7 @@ export const jsLoader: Loader = async (input, { options }) => {
   // esm => cjs
   const isCjs = options.format === "cjs";
   if (isCjs) {
-    // @ts-ignore
-    contents = jiti()
+    contents = jiti("")
       .transform({ source: contents, retainLines: false })
       .replace(/^exports.default = /gm, "module.exports = ");
   }

--- a/src/loaders/js.ts
+++ b/src/loaders/js.ts
@@ -33,12 +33,16 @@ export const jsLoader: Loader = async (input, { options }) => {
 
   // typescript => js
   if (input.extension === ".ts") {
-    contents = await transform(contents, { loader: "ts" }).then((r) => r.code);
+    contents = await transform(contents, {
+      ...options.esbuildOptions,
+      loader: "ts",
+    }).then((r) => r.code);
   }
 
   // esm => cjs
   const isCjs = options.format === "cjs";
   if (isCjs) {
+    // @ts-ignore
     contents = jiti()
       .transform({ source: contents, retainLines: false })
       .replace(/^exports.default = /gm, "module.exports = ");

--- a/src/loaders/js.ts
+++ b/src/loaders/js.ts
@@ -34,7 +34,7 @@ export const jsLoader: Loader = async (input, { options }) => {
   // typescript => js
   if (input.extension === ".ts") {
     contents = await transform(contents, {
-      ...options.esbuildOptions,
+      ...options.esbuild,
       loader: "ts",
     }).then((r) => r.code);
   }

--- a/src/make.ts
+++ b/src/make.ts
@@ -49,6 +49,7 @@ export async function mkdist(
     format: options.format,
     ext: options.ext,
     declaration: options.declaration,
+    esbuildOptions: options.esbuildOptions,
   });
 
   // Use loaders to get output files

--- a/src/make.ts
+++ b/src/make.ts
@@ -49,7 +49,7 @@ export async function mkdist(
     format: options.format,
     ext: options.ext,
     declaration: options.declaration,
-    esbuildOptions: options.esbuildOptions,
+    esbuild: options.esbuild,
   });
 
   // Use loaders to get output files

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -264,7 +264,7 @@ describe("mkdist", () => {
       );
     });
 
-    it("jsLoader options should support esbuild as property", async () => {
+    it("jsLoader: respect esbuild options", async () => {
       const { loadFile } = createLoader({
         loaders: [jsLoader],
         declaration: true,
@@ -272,18 +272,13 @@ describe("mkdist", () => {
           keepNames: true,
         },
       });
-      const results = await loadFile({
-        extension: ".ts",
-        getContents: () => "function testFunctionName() {}",
-        path: "test.ts",
-      });
-      expect(results).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            contents: expect.stringContaining("Object.defineProperty"),
-          }),
-        ])
-      );
+      const results =
+        (await loadFile({
+          extension: ".ts",
+          getContents: () => "function testFunctionName() {}",
+          path: "test.ts",
+        })) || [];
+      expect(results[1].contents).includes("Object.defineProperty");
     });
   });
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -264,11 +264,11 @@ describe("mkdist", () => {
       );
     });
 
-    it("jsLoader options should support esbuildOptions as property", async () => {
+    it("jsLoader options should support esbuild as property", async () => {
       const { loadFile } = createLoader({
         loaders: [jsLoader],
         declaration: true,
-        esbuildOptions: {
+        esbuild: {
           keepNames: true,
         },
       });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -263,5 +263,27 @@ describe("mkdist", () => {
         expect.arrayContaining([expect.objectContaining({ declaration: true })])
       );
     });
+
+    it("jsLoader options should support esbuildOptions as property", async () => {
+      const { loadFile } = createLoader({
+        loaders: [jsLoader],
+        declaration: true,
+        esbuildOptions: {
+          keepNames: true,
+        },
+      });
+      const results = await loadFile({
+        extension: ".ts",
+        getContents: () => "function testFunctionName() {}",
+        path: "test.ts",
+      });
+      expect(results).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            contents: expect.stringContaining("Object.defineProperty"),
+          }),
+        ])
+      );
+    });
   });
 });


### PR DESCRIPTION
This pr is related to issue: #39 
add esbuildOptions as prop to createLoader thus can make jsLoader using custom esbuild options while doing esbuild transform:
<img width="506" alt="image" src="https://user-images.githubusercontent.com/6498327/228721953-82e04ef1-d559-4682-83aa-49569afe4c67.png">
