### PR TITLE
feat: support configurable loaders

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -66,10 +66,14 @@ const main = defineCommand({
       description: "JSX fragment",
       valueHint: "Fragment|React.Fragment",
     },
+    loaders: {
+      type: "string",
+      description: "Loaders",
+      valueHint: "js|vue|sass",
+    }
   },
   async run({ args }) {
     const { writtenFiles } = await mkdist({
-      ...args,
       rootDir: resolve(args.cwd || process.cwd(), args.dir),
       srcDir: args.src,
       distDir: args.dist,
@@ -77,6 +81,7 @@ const main = defineCommand({
       pattern: args.pattern,
       ext: args.ext,
       declaration: args.declaration,
+      loaders: args.loaders?.split(","),
       esbuild: {
         jsx: args.jsx,
         jsxFactory: args.jsxFactory,

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -1,5 +1,5 @@
 import type { CommonOptions } from "esbuild";
-import { vueLoader, jsLoader, sassLoader } from "./loaders";
+import { LoaderName, resolveLoaders } from "./loaders";
 
 export interface InputFile {
   path: string;
@@ -44,14 +44,12 @@ export type Loader = (
   context: LoaderContext
 ) => LoaderResult | Promise<LoaderResult>;
 
-export const defaultLoaders: Loader[] = [vueLoader, jsLoader, sassLoader];
-
 export interface CreateLoaderOptions extends LoaderOptions {
-  loaders?: Loader[];
+  loaders?: (Loader | LoaderName)[];
 }
 
 export function createLoader(loaderOptions: CreateLoaderOptions = {}) {
-  const loaders = loaderOptions.loaders || defaultLoaders;
+  const loaders = resolveLoaders(loaderOptions.loaders);
 
   const loadFile: LoadFile = async function (input: InputFile) {
     const context: LoaderContext = {

--- a/src/loaders/index.ts
+++ b/src/loaders/index.ts
@@ -1,3 +1,27 @@
-export * from "./js";
-export * from "./sass";
-export * from "./vue";
+import type { Loader } from "../loader";
+import { jsLoader } from "./js";
+import { vueLoader } from "./vue";
+import { sassLoader } from "./sass";
+
+export const loaders = {
+  js: jsLoader,
+  vue: vueLoader,
+  sass: sassLoader,
+};
+
+export type LoaderName = keyof typeof loaders;
+
+export const defaultLoaders: LoaderName[] = ["js", "vue", "sass"];
+
+export function resolveLoader(loader: LoaderName | Loader) {
+  if (typeof loader === "string") {
+    return loaders[loader];
+  }
+  return loader;
+}
+
+export function resolveLoaders(
+  loaders: (LoaderName | Loader)[] = defaultLoaders
+) {
+  return loaders.map((loader) => resolveLoader(loader)).filter(Boolean);
+}

--- a/src/loaders/js.ts
+++ b/src/loaders/js.ts
@@ -39,7 +39,7 @@ export const jsLoader: Loader = async (input, { options }) => {
   // esm => cjs
   const isCjs = options.format === "cjs";
   if (isCjs) {
-    contents = jiti()
+    contents = jiti("")
       .transform({ source: contents, retainLines: false })
       .replace(/^exports.default = /gm, "module.exports = ");
   }

--- a/src/make.ts
+++ b/src/make.ts
@@ -54,7 +54,7 @@ export async function mkdist(
   let loaders;
   if (options.loaders) {
     loaders = [];
-    for (const loaderName of options.loaders || ["jsLoader", "vueLoader"]) {
+    for (const loaderName of options.loaders) {
       console.log("Loader", loaderName);
       loaders.push(allLoaders[loaderName]);
     }

--- a/src/make.ts
+++ b/src/make.ts
@@ -1,12 +1,15 @@
 import { resolve, extname, join, basename, dirname } from "pathe";
 import fse from "fs-extra";
 import { copyFileWithStream } from "./utils/fs";
-import { InputFile, LoaderOptions, createLoader, OutputFile } from "./loader";
+import {
+  InputFile,
+  LoaderOptions,
+  createLoader,
+  OutputFile,
+  Loader,
+} from "./loader";
 import { getDeclarations } from "./utils/dts";
-/* eslint import/namespace: ['error', { allowComputed: true }] */
-import * as allLoaders from "./loaders";
-
-type LoaderName = keyof typeof allLoaders;
+import { LoaderName } from "./loaders";
 
 export interface MkdistOptions extends LoaderOptions {
   rootDir?: string;
@@ -14,7 +17,7 @@ export interface MkdistOptions extends LoaderOptions {
   pattern?: string | string[];
   distDir?: string;
   cleanDist?: boolean;
-  loaders?: LoaderName[];
+  loaders?: (LoaderName | Loader)[];
   addRelativeDeclarationExtensions?: boolean;
 }
 
@@ -50,22 +53,13 @@ export async function mkdist(
     };
   });
 
-  // Use only the loaders specified in options
-  let loaders;
-  if (options.loaders) {
-    loaders = [];
-    for (const loaderName of options.loaders) {
-      loaders.push(allLoaders[loaderName]);
-    }
-  }
-
   // Create loader
   const { loadFile } = createLoader({
     format: options.format,
     ext: options.ext,
     declaration: options.declaration,
     esbuild: options.esbuild,
-    loaders,
+    loaders: options.loaders,
   });
 
   // Use loaders to get output files

--- a/src/make.ts
+++ b/src/make.ts
@@ -55,7 +55,6 @@ export async function mkdist(
   if (options.loaders) {
     loaders = [];
     for (const loaderName of options.loaders) {
-      console.log("Loader", loaderName);
       loaders.push(allLoaders[loaderName]);
     }
   }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -146,6 +146,35 @@ describe("mkdist", () => {
     });
   });
 
+  it("mkdist (only jsLoader and vueLoader)", async () => {
+    const rootDir = resolve(__dirname, "fixture");
+    const { writtenFiles } = await mkdist({
+      rootDir,
+      loaders: ["jsLoader", "vueLoader"],
+    });
+    expect(writtenFiles.sort()).toEqual(
+      [
+        "dist/README.md",
+        "dist/demo.scss",
+        "dist/_base.scss",
+        "dist/foo.mjs",
+        "dist/foo.d.ts", // manual
+        "dist/index.mjs",
+        "dist/types.d.ts",
+        "dist/star/index.mjs",
+        "dist/star/other.mjs",
+        "dist/components/blank.vue",
+        "dist/components/js.vue",
+        "dist/components/script-setup-ts.vue",
+        "dist/components/ts.vue",
+        "dist/bar/index.mjs",
+        "dist/bar/esm.mjs",
+      ]
+        .map((f) => resolve(rootDir, f))
+        .sort()
+    );
+  });
+
   describe("createLoader", () => {
     it("loadFile returns undefined for an unsupported file", async () => {
       const { loadFile } = createLoader();

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -3,7 +3,6 @@ import { resolve } from "pathe";
 import { describe, it, expect, beforeEach } from "vitest";
 import { mkdist } from "../src/make";
 import { createLoader } from "../src/loader";
-import { jsLoader, sassLoader, vueLoader } from "../src/loaders";
 
 describe("mkdist", () => {
   it("mkdist", async () => {
@@ -160,7 +159,7 @@ describe("mkdist", () => {
     const rootDir = resolve(__dirname, "fixture");
     const { writtenFiles } = await mkdist({
       rootDir,
-      loaders: ["jsLoader", "vueLoader"],
+      loaders: ["js", "vue"],
     });
     expect(writtenFiles.sort()).toEqual(
       [
@@ -198,7 +197,7 @@ describe("mkdist", () => {
 
     it("vueLoader handles no transpilation of script tag", async () => {
       const { loadFile } = createLoader({
-        loaders: [vueLoader],
+        loaders: ["vue"],
       });
       const results = await loadFile({
         extension: ".vue",
@@ -210,7 +209,7 @@ describe("mkdist", () => {
 
     it("vueLoader handles script tags with attributes", async () => {
       const { loadFile } = createLoader({
-        loaders: [vueLoader, jsLoader],
+        loaders: ["vue", "js"],
       });
       const results = await loadFile({
         extension: ".vue",
@@ -224,7 +223,7 @@ describe("mkdist", () => {
 
     it("vueLoader handles style tags", async () => {
       const { loadFile } = createLoader({
-        loaders: [vueLoader, sassLoader],
+        loaders: ["vue", "sass"],
       });
       const results = await loadFile({
         extension: ".vue",
@@ -247,7 +246,7 @@ describe("mkdist", () => {
 
     it("vueLoader bypass <script setup>", async () => {
       const { loadFile } = createLoader({
-        loaders: [vueLoader, jsLoader],
+        loaders: ["vue", "js"],
       });
       const results = await loadFile({
         extension: ".vue",
@@ -259,7 +258,7 @@ describe("mkdist", () => {
 
     it("vueLoader will generate dts file", async () => {
       const { loadFile } = createLoader({
-        loaders: [vueLoader, jsLoader],
+        loaders: ["vue", "js"],
         declaration: true,
       });
       const results = await loadFile({
@@ -275,7 +274,7 @@ describe("mkdist", () => {
 
     it("jsLoader will generate dts file (.js)", async () => {
       const { loadFile } = createLoader({
-        loaders: [jsLoader],
+        loaders: ["js"],
         declaration: true,
       });
       const results = await loadFile({
@@ -290,7 +289,7 @@ describe("mkdist", () => {
 
     it("jsLoader will generate dts file (.ts)", async () => {
       const { loadFile } = createLoader({
-        loaders: [jsLoader],
+        loaders: ["js"],
         declaration: true,
       });
       const results = await loadFile({
@@ -305,7 +304,7 @@ describe("mkdist", () => {
 
     it("jsLoader: respect esbuild options", async () => {
       const { loadFile } = createLoader({
-        loaders: [jsLoader],
+        loaders: ["js"],
         declaration: true,
         esbuild: {
           keepNames: true,
@@ -323,7 +322,7 @@ describe("mkdist", () => {
 
   it("jsLoader: Support JSX", async () => {
     const { loadFile } = createLoader({
-      loaders: [jsLoader],
+      loaders: ["js"],
       declaration: true,
     });
     const results =
@@ -340,7 +339,7 @@ describe("mkdist", () => {
 
   it("jsLoader: Support TSX", async () => {
     const { loadFile } = createLoader({
-      loaders: [jsLoader],
+      loaders: ["js"],
       declaration: true,
     });
     const results =

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -176,6 +176,8 @@ describe("mkdist", () => {
         "dist/components/js.vue",
         "dist/components/script-setup-ts.vue",
         "dist/components/ts.vue",
+        "dist/components/jsx.mjs",
+        "dist/components/tsx.mjs",
         "dist/bar/index.mjs",
         "dist/bar/esm.mjs",
       ]


### PR DESCRIPTION
Pick and choose the loaders mkdist uses. This (theoretically) resolves #128, as one would be able to only include jsLoader and vueLoader. This would also be a good step in resolving nuxt/module-builder#90.

Adding that import for all the loaders in make.ts made the builder fuss up, I think I fixed that by giving jiti an empty string. I tried to implement this as elegantly as I could; hopefully this at least brings attention to the issue. 