### PR TITLE
fix: handle `.cts` and `.mts` as typescript

### DIFF
--- a/src/loaders/js.ts
+++ b/src/loaders/js.ts
@@ -6,11 +6,13 @@ import type { Loader, LoaderResult } from "../loader";
 const DECLARATION_RE = /\.d\.[cm]?ts$/;
 const CM_LETTER_RE = /(?<=\.)(c|m)(?=[jt]s$)/;
 
+const KNOWN_EXT_RE = /\.(c|m)?[jt]sx?$/;
+
+const TS_EXTS = new Set([".ts", ".mts", ".cts"]);
+
 export const jsLoader: Loader = async (input, { options }) => {
-  if (
-    ![".ts", ".js", ".cjs", ".mjs", ".tsx", ".jsx"].includes(input.extension) ||
-    DECLARATION_RE.test(input.path)
-  ) {
+  if (!KNOWN_EXT_RE.test(input.path) || DECLARATION_RE.test(input.path)) {
+    console.log("Ignoring file with known extension:", input.path);
     return;
   }
 
@@ -32,7 +34,7 @@ export const jsLoader: Loader = async (input, { options }) => {
   }
 
   // typescript => js
-  if (input.extension === ".ts") {
+  if (TS_EXTS.has(input.extension)) {
     contents = await transform(contents, {
       ...options.esbuild,
       loader: "ts",

--- a/test/fixture/src/ts/test1.mts
+++ b/test/fixture/src/ts/test1.mts
@@ -1,0 +1,1 @@
+export default "test1.mts" as string;

--- a/test/fixture/src/ts/test2.cts
+++ b/test/fixture/src/ts/test2.cts
@@ -1,0 +1,1 @@
+module.exports = "test2.cts" as string;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -26,6 +26,8 @@ describe("mkdist", () => {
         "dist/components/tsx.mjs",
         "dist/bar/index.mjs",
         "dist/bar/esm.mjs",
+        "dist/ts/test1.mjs",
+        "dist/ts/test2.mjs",
       ]
         .map((f) => resolve(rootDir, f))
         .sort()
@@ -105,6 +107,10 @@ describe("mkdist", () => {
         "dist/bar/index.d.ts",
         "dist/bar/esm.mjs",
         "dist/bar/esm.d.mts",
+        "dist/ts/test1.mjs",
+        "dist/ts/test2.mjs",
+        "dist/ts/test1.d.mts",
+        "dist/ts/test2.d.cts",
       ]
         .map((f) => resolve(rootDir, f))
         .sort()
@@ -180,6 +186,8 @@ describe("mkdist", () => {
         "dist/components/tsx.mjs",
         "dist/bar/index.mjs",
         "dist/bar/esm.mjs",
+        "dist/ts/test1.mjs",
+        "dist/ts/test2.mjs",
       ]
         .map((f) => resolve(rootDir, f))
         .sort()


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

Resolves #138

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Handle `.cts` and `.mts` as typescript sources and generate them into the output

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
