### PR TITLE
feat: introduce `alias` option support

### DIFF
--- a/test/fixture/src/index.ts
+++ b/test/fixture/src/index.ts
@@ -1,4 +1,4 @@
-import bar from "./bar";
+import bar from "~/bar";
 
 // eslint-disable-next-line @typescript-eslint/no-inferrable-types
 const foo: string = "foo";
@@ -6,6 +6,6 @@ const foo: string = "foo";
 export const importFoo = () => import("node:path");
 
 export const dynamicLibImport = () => import("node:module");
-export const dynamicImport = () => import("./bar");
+export const dynamicImport = () => import("~/bar");
 
 export default () => foo + bar;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -35,6 +35,25 @@ describe("mkdist", () => {
     );
   });
 
+  it("mkdist (resolve aliases)", async () => {
+    const rootDir = resolve(__dirname, "fixture");
+    const { writtenFiles } = await mkdist({
+      rootDir,
+      alias: { '~': resolve(rootDir, 'src') },
+      pattern: "index.ts",
+    });
+    expect(writtenFiles.sort()).toEqual(
+      [
+        "dist/index.mjs",
+      ]
+        .map((f) => resolve(rootDir, f))
+        .sort(),
+    );
+
+    const indexFile = await readFile(resolve(rootDir, "dist/index.mjs"), "utf8");
+    expect(indexFile).not.toMatch("~/bar");
+  });
+
   it("mkdist (custom glob pattern)", async () => {
     const rootDir = resolve(__dirname, "fixture");
     const { writtenFiles } = await mkdist({


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Implements `alias` support using `pathe`'s resolveAlias, similar to `jiti` and `unbuild` config.alias option

Related to [unbuild](https://github.com/unjs/unbuild) regarding alias breaking/not working in mkdist builder
Related issues: #202, unjs/unbuild#375, unjs/unbuild#289

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
