### PR TITLE
feat: process <script setup lang="ts> if there is no type-only macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,32 @@ While there are tools like [tsc](https://www.typescriptlang.org/docs/handbook/co
 npx mkdist [rootDir] [--src=src] [--dist=dist] [--pattern=glob [--pattern=more-glob]] [--format=cjs|esm] [-d|--declaration] [--ext=mjs|js|ts]
 ```
 
+## Vue Single File Components
+
+`<script lang="ts">` is transformed to `<script>` with JS content. The typings are extracted to a `.vue.d.ts` file (if `--declaration` is enabled).
+
+If using `<script setup lang="ts">` and type-only variant of macros, e.g. `defineProps<...>()`, the file will not be transformed.
+
+This will not be transformed:
+```html
+<script setup lang="ts">
+const props = defineProps<{ foo: string }>()
+</script>
+```
+But, this will be transformed:
+```html
+<script setup lang="ts">
+const props = defineProps({
+  foo: {
+    type: String,
+    required: true,
+  },
+})
+</script>
+```
+
+`<style lang="scss">`/`<style lang="sass">` is transformed to `<style>` with CSS content. It also supports the `scoped` attribute.
+
 ## License
 
 [MIT](./LICENSE)

--- a/test/fixture/src/components/script-setup-ts-with-type-only-macros.vue
+++ b/test/fixture/src/components/script-setup-ts-with-type-only-macros.vue
@@ -1,16 +1,13 @@
 <template>
-  <div>{{ str }} - {{ msg }}</div>
+  <div>{{ str }}</div>
 </template>
 
 <script setup lang="ts">
 import { ref } from "vue";
 
-const props = defineProps({
-  msg: {
-    type: String,
-    required: true,
-  },
-});
+const props = defineProps<{
+  msg: string;
+}>();
 
 const str = ref<string | number>("hello");
 </script>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
Resolves #209

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Some macros in `<script setup>` have a type-only variant:
- `defineProps`
- `defineEmits`
- `defineSlots`
- `defineModel`

As long as their type-only variant is NOT used, they can safely be transformed into JS. So, this PR improves the exclusion logic to exclude `<script setup>` only if the file contains some type-only macro usage.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
