### PR TITLE
feat: add declarationExt option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ While there are tools like [tsc](https://www.typescriptlang.org/docs/handbook/co
 ## 🚀 Usage
 
 ```bash
-npx mkdist [rootDir] [--src=src] [--dist=dist] [--pattern=glob [--pattern=more-glob]] [--format=cjs|esm] [-d|--declaration] [--ext=mjs|js|ts]
+npx mkdist [rootDir] [--src=src] [--dist=dist] [--pattern=glob [--pattern=more-glob]] [--format=cjs|esm] [-d|--declaration] [--ext=mjs|js|ts] [--declarationExt=infer|d.ts|d.mts|d.cts]
 ```
 
 ## License

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -46,6 +46,11 @@ const main = defineCommand({
       default: false,
       alias: ["d"],
     },
+    declarationExt: {
+      type: "string",
+      description: "Extensions for type declaration files",
+      valueHint: "infer|d.ts|d.mts|d.cts",
+    },
     ext: {
       type: "string",
       description: "File extension",
@@ -90,6 +95,7 @@ const main = defineCommand({
       pattern: args.pattern,
       ext: args.ext,
       declaration: args.declaration,
+      declarationExt: args.declarationExt,
       loaders: args.loaders?.split(","),
       esbuild: {
         jsx: args.jsx,

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -21,6 +21,7 @@ export interface OutputFile {
    */
   path: string;
   srcPath?: string;
+  srcExtension?: string;
   extension?: string;
   contents?: string;
   declaration?: boolean;
@@ -38,6 +39,7 @@ export interface LoaderOptions {
   ext?: "js" | "mjs" | "cjs" | "ts" | "mts" | "cts";
   format?: "cjs" | "esm";
   declaration?: boolean;
+  declarationExt?: "infer" | "d.ts" | "d.mts" | "d.cts";
   esbuild?: CommonOptions;
   postcss?:
     | false

--- a/src/loaders/vue.ts
+++ b/src/loaders/vue.ts
@@ -114,5 +114,5 @@ const scriptLoader = vueBlockLoader({
   outputLang: "js",
   type: "script",
   exclude: [/\bsetup\b/],
-  validExtensions: [".js", ".mjs"],
+  validExtensions: [".js", ".mjs", ".ts", ".mts"],
 });

--- a/src/make.ts
+++ b/src/make.ts
@@ -92,7 +92,8 @@ export async function mkdist(
   // Normalize output extensions
   for (const output of outputs.filter((o) => o.extension)) {
     const renamed =
-      basename(output.path, extname(output.path)) + output.extension;
+      basename(output.path, output.srcExtension ?? extname(output.path)) +
+      output.extension;
     output.path = join(dirname(output.path), renamed);
     // Avoid overriding files with original extension
     if (outputs.some((o) => o !== output && o.path === output.path)) {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -156,6 +156,190 @@ describe("mkdist", () => {
       `);
   }, 50_000);
 
+  describe("mkdist (declarationExt: infer)", () => {
+    it.each([
+      {
+        format: "cjs",
+        ext: undefined,
+        implicitFiles: [
+          "dist/foo.js",
+          "dist/foo.d.ts",
+          "dist/index.js",
+          "dist/index.d.ts",
+          "dist/star/index.js",
+          "dist/star/index.d.ts",
+          "dist/star/other.js",
+          "dist/star/other.d.ts",
+          "dist/types.d.ts",
+          "dist/bar/index.js",
+          "dist/bar/index.d.ts",
+          "dist/bar/esm.js",
+          "dist/bar/esm.d.ts",
+          "dist/ts/test1.js",
+          "dist/ts/test2.js",
+          "dist/ts/test1.d.ts",
+          "dist/ts/test2.d.ts",
+          "dist/components/js.vue.d.ts",
+          "dist/components/ts.vue.d.ts",
+          "dist/components/jsx.js",
+          "dist/components/tsx.js",
+          "dist/components/jsx.d.ts",
+          "dist/components/tsx.d.ts",
+        ],
+      },
+      // not setting the format explicitly should work like esm
+      ...(["esm", undefined] as const).map((format) => ({
+        format,
+        ext: undefined,
+        implicitFiles: [
+          "dist/foo.mjs",
+          "dist/foo.d.mts",
+          "dist/index.mjs",
+          "dist/index.d.mts",
+          "dist/star/index.mjs",
+          "dist/star/index.d.mts",
+          "dist/star/other.mjs",
+          "dist/star/other.d.mts",
+          "dist/types.d.mts",
+          "dist/bar/index.mjs",
+          "dist/bar/index.d.mts",
+          "dist/bar/esm.mjs",
+          "dist/bar/esm.d.mts",
+          "dist/ts/test1.mjs",
+          "dist/ts/test2.mjs",
+          "dist/ts/test1.d.mts",
+          "dist/ts/test2.d.mts",
+          "dist/components/js.vue.d.mts",
+          "dist/components/ts.vue.d.mts",
+          "dist/components/jsx.mjs",
+          "dist/components/tsx.mjs",
+          "dist/components/jsx.d.mts",
+          "dist/components/tsx.d.mts",
+        ],
+      })),
+      ...(["cjs", "esm", undefined] as const).flatMap((format) =>
+        (["js", "mjs", "cjs", "ts", "mts", "cts"] as const).map((ext) => {
+          const [srcExt, dtsExt, emitsVue = false] = {
+            js: ["js", "d.ts", true],
+            mjs: ["mjs", "d.mts", true],
+            cjs: ["cjs", "d.cts"],
+            ts: ["ts", "d.ts", true],
+            mts: ["mts", "d.mts", true],
+            cts: ["cts", "d.cts"],
+          }[ext];
+
+          return {
+            format,
+            ext,
+            implicitFiles: [
+              `dist/foo.${srcExt}`,
+              `dist/foo.${dtsExt}`,
+              `dist/index.${srcExt}`,
+              `dist/index.${dtsExt}`,
+              `dist/star/index.${srcExt}`,
+              `dist/star/index.${dtsExt}`,
+              `dist/star/other.${srcExt}`,
+              `dist/star/other.${dtsExt}`,
+              `dist/types.${dtsExt}`,
+              `dist/bar/index.${srcExt}`,
+              `dist/bar/index.${dtsExt}`,
+              `dist/bar/esm.${srcExt}`,
+              `dist/bar/esm.${dtsExt}`,
+              `dist/ts/test1.${srcExt}`,
+              `dist/ts/test2.${srcExt}`,
+              `dist/ts/test1.${dtsExt}`,
+              `dist/ts/test2.${dtsExt}`,
+              `dist/components/jsx.${srcExt}`,
+              `dist/components/tsx.${srcExt}`,
+              `dist/components/jsx.${dtsExt}`,
+              `dist/components/tsx.${dtsExt}`,
+              ...(emitsVue
+                ? [
+                    `dist/components/js.vue.${dtsExt}`,
+                    `dist/components/ts.vue.${dtsExt}`,
+                  ]
+                : []),
+            ],
+          };
+        }),
+      ),
+    ] as const)(
+      "format: $format, ext: $ext",
+      async ({ format, ext, implicitFiles }) => {
+        const rootDir = resolve(__dirname, "fixture");
+        const { writtenFiles } = await mkdist({
+          rootDir,
+          format,
+          ext,
+          declaration: true,
+          declarationExt: "infer",
+        });
+        expect(writtenFiles.sort()).toEqual(
+          [
+            "dist/README.md",
+            "dist/demo.css",
+            "dist/components/blank.vue",
+            "dist/components/js.vue",
+            "dist/components/script-setup-ts.vue",
+            "dist/components/ts.vue",
+            "dist/nested.css",
+            ...implicitFiles,
+          ]
+            .map((f) => resolve(rootDir, f))
+            .sort(),
+        );
+      },
+    );
+  }, 50_000);
+
+  it.each(["d.ts", "d.mts", "d.cts"] as const)(
+    "mkdist (declarationExt: %s)",
+    async (declarationExt) => {
+      const rootDir = resolve(__dirname, "fixture");
+      const { writtenFiles } = await mkdist({
+        rootDir,
+        declaration: true,
+        declarationExt,
+      });
+      expect(writtenFiles.sort()).toEqual(
+        [
+          "dist/README.md",
+          "dist/demo.css",
+          "dist/foo.mjs",
+          `dist/foo.${declarationExt}`,
+          "dist/index.mjs",
+          `dist/index.${declarationExt}`,
+          "dist/star/index.mjs",
+          `dist/star/index.${declarationExt}`,
+          "dist/star/other.mjs",
+          `dist/star/other.${declarationExt}`,
+          `dist/types.${declarationExt}`,
+          "dist/components/blank.vue",
+          "dist/components/js.vue",
+          `dist/components/js.vue.${declarationExt}`,
+          "dist/components/script-setup-ts.vue",
+          "dist/components/ts.vue",
+          `dist/components/ts.vue.${declarationExt}`,
+          "dist/components/jsx.mjs",
+          "dist/components/tsx.mjs",
+          `dist/components/jsx.${declarationExt}`,
+          `dist/components/tsx.${declarationExt}`,
+          "dist/bar/index.mjs",
+          `dist/bar/index.${declarationExt}`,
+          "dist/bar/esm.mjs",
+          `dist/bar/esm.${declarationExt}`,
+          "dist/ts/test1.mjs",
+          "dist/ts/test2.mjs",
+          `dist/ts/test1.${declarationExt}`,
+          `dist/ts/test2.${declarationExt}`,
+          "dist/nested.css",
+        ]
+          .map((f) => resolve(rootDir, f))
+          .sort(),
+      );
+    },
+  );
+
   describe("mkdist (sass compilation)", () => {
     const rootDir = resolve(__dirname, "fixture");
     let writtenFiles: string[];


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Adds `declarationExt` option that allows customizing extensions of `.d.ts` files.

The option behaves like this:
- `declarationExt: undefined`
  - keeps the previous behavior (follows the sources' module format prefix (`c|m`) if available, otherwise `.d.ts`) 
- `declarationExt: "d.ts" | "d.mts" | "d.cts"`
  - forces every declaration file emitted to have the configured extension.
- `declarationExt: "infer"`
  - infers the desired extension of declaration files based on other options like `ext` and `format`.
  - if `ext` is set, follows its module format prefix (`c | m`) if available, otherwise `.d.ts`
  - if `format` is set to `"cjs"`, `.d.ts`
  - if `format` is not set or set to `"esm"`, `.d.mts`

By introducing this option, it enables users to get declaration files with the correct extensions they should be. It was previously impossible to achieve when emitting multiple format of modules from a single source, since it would always emit `.d.ts` in that case. Now users can explicitly set `declarationExt` to have desired extensions, or use `"infer"` to let mkdist decide the best one.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
