### PR TITLE
fix(dts): use `ts.convertCompilerOptionsFromJson` to normalise

### DIFF
--- a/src/make.ts
+++ b/src/make.ts
@@ -61,11 +61,6 @@ export async function mkdist(
 
   // Read and normalise TypeScript compiler options for emitting declarations
   options.typescript ||= {};
-  if (options.typescript.compilerOptions) {
-    options.typescript.compilerOptions = await normalizeCompilerOptions(
-      options.typescript.compilerOptions,
-    );
-  }
   options.typescript.compilerOptions = defu(
     { noEmit: false },
     options.typescript.compilerOptions,
@@ -79,6 +74,12 @@ export async function mkdist(
       allowNonTsExtensions: true,
     },
   );
+
+  if (options.typescript.compilerOptions) {
+    options.typescript.compilerOptions = await normalizeCompilerOptions(
+      options.typescript.compilerOptions,
+    );
+  }
 
   // Create loader
   const { loadFile } = createLoader(options);

--- a/src/make.ts
+++ b/src/make.ts
@@ -61,6 +61,11 @@ export async function mkdist(
 
   // Read and normalise TypeScript compiler options for emitting declarations
   options.typescript ||= {};
+  if (options.typescript.compilerOptions) {
+    options.typescript.compilerOptions = await normalizeCompilerOptions(
+      options.typescript.compilerOptions,
+    );
+  }
   options.typescript.compilerOptions = defu(
     { noEmit: false },
     options.typescript.compilerOptions,
@@ -74,12 +79,6 @@ export async function mkdist(
       allowNonTsExtensions: true,
     },
   );
-
-  if (options.typescript.compilerOptions) {
-    options.typescript.compilerOptions = await normalizeCompilerOptions(
-      options.typescript.compilerOptions,
-    );
-  }
 
   // Create loader
   const { loadFile } = createLoader(options);

--- a/src/utils/dts.ts
+++ b/src/utils/dts.ts
@@ -6,25 +6,7 @@ export async function normalizeCompilerOptions(
   _options: TSConfig["compilerOptions"],
 ) {
   const ts = await import("typescript").then((r) => r.default || r);
-  const configMap = {
-    importsNotUsedAsValues: ts.ImportsNotUsedAsValues,
-    moduleResolution: ts.ModuleResolutionKind,
-    moduleDetection: ts.ModuleDetectionKind,
-    newLine: ts.NewLineKind,
-    target: ts.ScriptTarget,
-  };
-  const compilerOptions = { ..._options };
-  for (const key in configMap) {
-    if (key in compilerOptions) {
-      if (configMap[key][compilerOptions[key]]) {
-        compilerOptions[key] = configMap[key][compilerOptions[key]];
-      } else {
-        console.warn("Could not map", key, compilerOptions[key]);
-        delete compilerOptions[key];
-      }
-    }
-  }
-  return compilerOptions;
+  return ts.convertCompilerOptionsFromJson(_options, process.cwd()).options;
 }
 
 export async function getDeclarations(


### PR DESCRIPTION
https://github.com/nuxt/module-builder/issues/297
https://github.com/nuxt/module-builder/issues/299

Previously we were rather naively normalising tsconfig options but we do have the ability to do that from ts itself.
