### PR TITLE
refactor: replace `fs-extra` w/ native fs API

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "cssnano": "^7.0.4",
     "defu": "^6.1.4",
     "esbuild": "^0.23.0",
-    "fs-extra": "^11.2.0",
     "globby": "^14.0.2",
     "jiti": "^1.21.6",
     "mlly": "^1.7.1",
@@ -46,7 +45,6 @@
     "semver": "^7.6.2"
   },
   "devDependencies": {
-    "@types/fs-extra": "^11.0.4",
     "@types/mri": "^1.2.0",
     "@types/node": "^20.14.10",
     "@types/semver": "^7.5.8",
@@ -64,8 +62,8 @@
     "unbuild": "^2.0.0",
     "vitest": "^1.6.0",
     "vue": "^3.4.31",
-    "vue-tsc1": "npm:vue-tsc@^1.8.27",
-    "vue-tsc": "^2.0.26"
+    "vue-tsc": "^2.0.26",
+    "vue-tsc1": "npm:vue-tsc@^1.8.27"
   },
   "peerDependencies": {
     "sass": "^1.77.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       esbuild:
         specifier: ^0.23.0
         version: 0.23.0
-      fs-extra:
-        specifier: ^11.2.0
-        version: 11.2.0
       globby:
         specifier: ^14.0.2
         version: 14.0.2
@@ -54,9 +51,6 @@ importers:
         specifier: ^7.6.2
         version: 7.6.2
     devDependencies:
-      '@types/fs-extra':
-        specifier: ^11.0.4
-        version: 11.0.4
       '@types/mri':
         specifier: ^1.2.0
         version: 1.2.0
@@ -718,14 +712,8 @@ packages:
   '@types/estree@1.0.5':
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
 
-  '@types/fs-extra@11.0.4':
-    resolution: {integrity: sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==}
-
   '@types/istanbul-lib-coverage@2.0.6':
     resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
-
-  '@types/jsonfile@6.1.4':
-    resolution: {integrity: sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==}
 
   '@types/mdast@3.0.15':
     resolution: {integrity: sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==}
@@ -3358,16 +3346,7 @@ snapshots:
 
   '@types/estree@1.0.5': {}
 
-  '@types/fs-extra@11.0.4':
-    dependencies:
-      '@types/jsonfile': 6.1.4
-      '@types/node': 20.14.10
-
   '@types/istanbul-lib-coverage@2.0.6': {}
-
-  '@types/jsonfile@6.1.4':
-    dependencies:
-      '@types/node': 20.14.10
 
   '@types/mdast@3.0.15':
     dependencies:


### PR DESCRIPTION
The PR replaces all `fs-extra` usage w/ Node.js native fs API.

- `fse.emptyDir`
  - Repalced by `fsPromise.rm`, available since Node.js 14.14
- `fse.mkdirp`
  - Replaced by `fsPromise.mkdir`, available since Node.js 10.10