### PR TITLE
fix(dts): compatible with `vue-tsc` 2.0.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@vitest/coverage-v8": "^2.0.5",
     "@volar/typescript": "^2.4.1",
     "@vue/language-core": "^2.1.2",
+    "@vue/language-core2.0": "npm:@vue/language-core@2.0.29",
     "c8": "latest",
     "changelogen": "^0.5.5",
     "eslint": "^9.9.0",
@@ -62,7 +63,7 @@
     "vue": "^3.4.38",
     "vue-tsc": "^2.1.2",
     "vue-tsc1": "npm:vue-tsc@^1.8.27",
-    "vue-tsc2.0": "npm:vue-tsc@~2.0.29"
+    "vue-tsc2.0": "npm:vue-tsc@2.0.29"
   },
   "peerDependencies": {
     "sass": "^1.77.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       '@vue/language-core':
         specifier: ^2.1.2
         version: 2.1.2(typescript@5.5.4)
+      '@vue/language-core2.0':
+        specifier: npm:@vue/language-core@2.0.29
+        version: '@vue/language-core@2.0.29(typescript@5.5.4)'
       c8:
         specifier: latest
         version: 10.1.2
@@ -103,7 +106,7 @@ importers:
         specifier: npm:vue-tsc@^1.8.27
         version: vue-tsc@1.8.27(typescript@5.5.4)
       vue-tsc2.0:
-        specifier: npm:vue-tsc@~2.0.29
+        specifier: npm:vue-tsc@2.0.29
         version: vue-tsc@2.0.29(typescript@5.5.4)
 
 packages:

--- a/src/utils/vue-dts.ts
+++ b/src/utils/vue-dts.ts
@@ -1,8 +1,8 @@
 import { createRequire } from "node:module";
 import { CompilerOptions, CreateProgramOptions } from "typescript";
 import { readPackageJSON } from "pkg-types";
-import { resolve as resolveModule } from "mlly";
-import { major } from "semver";
+import { satisfies } from "semver";
+import { normalize } from "pathe";
 import { MkdistOptions } from "../make";
 import { extractDeclarations } from "./dts";
 
@@ -27,15 +27,18 @@ export async function getVueDeclarations(
     return;
   }
 
-  const majorVersion = major(pkgInfo.version);
-  switch (majorVersion) {
-    case 1: {
+  const { version } = pkgInfo;
+  switch (true) {
+    case satisfies(version, "^1.8.27"): {
       await emitVueTscV1(vfs, opts.typescript.compilerOptions, srcFiles);
       break;
     }
-    case 2: {
+    case satisfies(version, "~v2.0.0"): {
       await emitVueTscV2(vfs, opts.typescript.compilerOptions, srcFiles);
       break;
+    }
+    default: {
+      await emitVueTscLatest(vfs, opts.typescript.compilerOptions, srcFiles);
     }
   }
 
@@ -103,6 +106,75 @@ async function emitVueTscV2(
   compilerOptions: CompilerOptions,
   srcFiles: string[],
 ) {
+  const { resolve: resolveModule } = await import("mlly");
+  const ts: typeof import("typescript") = await import("typescript").then(
+    (r) => r.default || r,
+  );
+  const vueTsc = (await import(
+    "vue-tsc"
+  )) as unknown as typeof import("vue-tsc2.0");
+  const requireFromVueTsc = createRequire(await resolveModule("vue-tsc"));
+  const vueLanguageCore: typeof import("@vue/language-core2.0") =
+    requireFromVueTsc("@vue/language-core");
+  const volarTs: typeof import("@volar/typescript") =
+    requireFromVueTsc("@volar/typescript");
+
+  const tsHost = ts.createCompilerHost(compilerOptions);
+  tsHost.writeFile = (filename, content) => {
+    vfs.set(filename, vueTsc.removeEmitGlobalTypes(content));
+  };
+  const _tsReadFile = tsHost.readFile.bind(tsHost);
+  tsHost.readFile = (filename) => {
+    if (vfs.has(filename)) {
+      return vfs.get(filename);
+    }
+    return _tsReadFile(filename);
+  };
+  const _tsFileExist = tsHost.fileExists.bind(tsHost);
+  tsHost.fileExists = (filename) => {
+    return vfs.has(filename) || _tsFileExist(filename);
+  };
+  const programOptions: CreateProgramOptions = {
+    rootNames: srcFiles,
+    options: compilerOptions,
+    host: tsHost,
+  };
+  const createProgram = volarTs.proxyCreateProgram(
+    ts,
+    ts.createProgram,
+    (ts, options) => {
+      const vueLanguagePlugin = vueLanguageCore.createVueLanguagePlugin<string>(
+        ts,
+        (id) => id,
+        () => "",
+        (fileName) => {
+          const fileMap = new Set();
+          for (const vueFileName of options.rootNames.map((rootName) =>
+            normalize(rootName),
+          )) {
+            fileMap.add(vueFileName);
+          }
+          return fileMap.has(fileName);
+        },
+        options.options,
+        vueLanguageCore.resolveVueCompilerOptions({}),
+      );
+      return [vueLanguagePlugin];
+    },
+  );
+  const program = createProgram(programOptions);
+  const result = program.emit();
+  if (result.diagnostics?.length) {
+    console.error(ts.formatDiagnostics(result.diagnostics, tsHost));
+  }
+}
+
+async function emitVueTscLatest(
+  vfs: Map<string, string>,
+  compilerOptions: CompilerOptions,
+  srcFiles: string[],
+) {
+  const { resolve: resolveModule } = await import("mlly");
   const ts: typeof import("typescript") = await import("typescript").then(
     (r) => r.default || r,
   );

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -512,6 +512,19 @@ describe("mkdist with vue-tsc ~v2.0.21", () => {
         },
       };
     });
+    vi.doMock("mlly", async () => {
+      const original = await import("mlly");
+      const resolve: typeof import("mlly").resolve = (id, options) => {
+        if (id === "vue-tsc") {
+          return original.resolve("vue-tsc2.0", options);
+        }
+        return original.resolve(id, options);
+      };
+      return {
+        ...original,
+        resolve,
+      };
+    });
     vi.doMock("vue-tsc", async () => {
       return await import("vue-tsc2.0");
     });


### PR DESCRIPTION
Fixed [Comment in #240](https://github.com/unjs/mkdist/pull/240#issuecomment-2326976000) 

This PR fixes forward compatibility with `vue-tsc@~2.0.12` and the wrong test case, now mkdist should work well with all vue-tsc matching the peerDependence requirement.