### PR TITLE
fix(vue): skip transpilation with multiple script blocks

### DIFF
--- a/src/loaders/vue.ts
+++ b/src/loaders/vue.ts
@@ -51,7 +51,7 @@ const vueBlockLoader =
 
     const BLOCK_RE = new RegExp(
       `<${options.type}((\\s[^>\\s]*)*)>([\\S\\s.]*?)<\\/${options.type}>`,
-      'g',
+      "g",
     );
 
     const matches = [...contents.matchAll(BLOCK_RE)];
@@ -60,8 +60,8 @@ const vueBlockLoader =
     }
 
     // TODO: support merging <script> blocks
-    if (options.type === 'script' && matches.length > 1) {
-      return
+    if (options.type === "script" && matches.length > 1) {
+      return;
     }
 
     const [block, attributes = "", _, blockContents] = matches[0];

--- a/src/loaders/vue.ts
+++ b/src/loaders/vue.ts
@@ -51,10 +51,20 @@ const vueBlockLoader =
 
     const BLOCK_RE = new RegExp(
       `<${options.type}((\\s[^>\\s]*)*)>([\\S\\s.]*?)<\\/${options.type}>`,
+      'g',
     );
 
-    const [block, attributes = "", _, blockContents] =
-      contents.match(BLOCK_RE) || [];
+    const matches = [...contents.matchAll(BLOCK_RE)];
+    if (matches.length === 0) {
+      return;
+    }
+
+    // TODO: support merging <script> blocks
+    if (options.type === 'script' && matches.length > 1) {
+      return
+    }
+
+    const [block, attributes = "", _, blockContents] = matches[0];
 
     if (!block || !blockContents) {
       return;

--- a/test/fixture/src/components/script-multi-block.vue
+++ b/test/fixture/src/components/script-multi-block.vue
@@ -1,0 +1,13 @@
+<template>
+  <div>{{ msg }}</div>
+</template>
+
+<script lang="ts">
+interface MyComponentProps {
+  msg: string;
+}
+</script>
+
+<script setup lang="ts">
+defineProps<MyComponentProps>();
+</script>

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -33,6 +33,7 @@ describe("mkdist", () => {
         "dist/star/other.mjs",
         "dist/components/blank.vue",
         "dist/components/js.vue",
+        "dist/components/script-multi-block.vue",
         "dist/components/script-setup-ts.vue",
         "dist/components/ts.vue",
         "dist/components/jsx.mjs",
@@ -58,6 +59,7 @@ describe("mkdist", () => {
       [
         "dist/components/blank.vue",
         "dist/components/js.vue",
+        "dist/components/script-multi-block.vue",
         "dist/components/script-setup-ts.vue",
         "dist/components/ts.vue",
         "dist/components/jsx.mjs",
@@ -77,6 +79,7 @@ describe("mkdist", () => {
     expect(writtenFiles.sort()).toEqual(
       [
         "dist/components/blank.vue",
+        "dist/components/script-multi-block.vue",
         "dist/components/script-setup-ts.vue",
         "dist/components/ts.vue",
         "dist/components/jsx.mjs",
@@ -110,6 +113,7 @@ describe("mkdist", () => {
         "dist/components/blank.vue",
         "dist/components/js.vue",
         "dist/components/js.vue.d.ts",
+        "dist/components/script-multi-block.vue",
         "dist/components/script-setup-ts.vue",
         "dist/components/ts.vue",
         "dist/components/ts.vue.d.ts",
@@ -205,6 +209,7 @@ describe("mkdist", () => {
         "dist/star/other.mjs",
         "dist/components/blank.vue",
         "dist/components/js.vue",
+        "dist/components/script-multi-block.vue",
         "dist/components/script-setup-ts.vue",
         "dist/components/ts.vue",
         "dist/components/jsx.mjs",
@@ -448,6 +453,7 @@ describe("mkdist with vue-tsc v1", () => {
         "dist/components/blank.vue",
         "dist/components/js.vue",
         "dist/components/js.vue.d.ts",
+        "dist/components/script-multi-block.vue",
         "dist/components/script-setup-ts.vue",
         "dist/components/ts.vue",
         "dist/components/ts.vue.d.ts",
@@ -560,6 +566,7 @@ describe("mkdist with vue-tsc ~v2.0.21", () => {
         "dist/components/blank.vue",
         "dist/components/js.vue",
         "dist/components/js.vue.d.ts",
+        "dist/components/script-multi-block.vue",
         "dist/components/script-setup-ts.vue",
         "dist/components/ts.vue",
         "dist/components/ts.vue.d.ts",
@@ -603,6 +610,28 @@ describe("mkdist with vue-tsc ~v2.0.21", () => {
           str: "test";
       }, {}, {}, import("vue").ComponentOptionsMixin, import("vue").ComponentOptionsMixin, {}, string, import("vue").PublicProps, Readonly<{}> & Readonly<{}>, {}, {}, {}, {}, string, import("vue").ComponentProvideOptions, true, {}, any>;
       export default _default;
+      "
+    `);
+
+    expect(
+      await readFile(
+        resolve(rootDir, "dist/components/script-multi-block.vue"),
+        "utf8",
+      ),
+    ).toMatchInlineSnapshot(`
+      "<template>
+        <div>{{ msg }}</div>
+      </template>
+
+      <script lang="ts">
+      interface MyComponentProps {
+        msg: string;
+      }
+      </script>
+
+      <script setup lang="ts">
+      defineProps<MyComponentProps>();
+      </script>
       "
     `);
   }, 50_000);


### PR DESCRIPTION
`mkdist` currently only transforms first block of each type in vue files.

This is a hotfix to handle an issue where the first `<script>` block is transpiled, and the second one isn't, which yields a vue compiler error (because `lang` should match between script blocks).

We would need to support handling multiple script blocks in future.

related: https://github.com/unjs/mkdist/issues/209