### PR TITLE
fix(dts): resolve directory exports in `.dts` files

### DIFF
--- a/src/utils/dts.ts
+++ b/src/utils/dts.ts
@@ -1,4 +1,6 @@
+import { statSync } from "node:fs";
 import { findStaticImports, findExports, findTypeExports } from "mlly";
+import { join, resolve } from "pathe";
 import type { TSConfig } from "pkg-types";
 import type { MkdistOptions } from "../make";
 
@@ -63,10 +65,21 @@ export function extractDeclarations(
         if (!spec.specifier || !/^\.{1,2}[/\\]/.test(spec.specifier)) {
           continue;
         }
+        let isDir = false;
+        try {
+          isDir = statSync(
+            resolve(filename, "..", spec.specifier),
+          ).isDirectory();
+        } catch {
+          // file does not exist
+        }
         // add file extension for relative paths (`.js` will match the `.d.ts` extension we emit)
         contents = contents.replace(
           spec.code,
-          spec.code.replace(spec.specifier, spec.specifier + ext),
+          spec.code.replace(
+            spec.specifier,
+            isDir ? join(spec.specifier, "index" + ext) : spec.specifier + ext,
+          ),
         );
       }
     }

--- a/src/utils/dts.ts
+++ b/src/utils/dts.ts
@@ -1,6 +1,6 @@
 import { statSync } from "node:fs";
 import { findStaticImports, findExports, findTypeExports } from "mlly";
-import { join, resolve } from "pathe";
+import { resolve } from "pathe";
 import type { TSConfig } from "pkg-types";
 import type { MkdistOptions } from "../make";
 
@@ -78,7 +78,7 @@ export function extractDeclarations(
           spec.code,
           spec.code.replace(
             spec.specifier,
-            isDir ? join(spec.specifier, "index" + ext) : spec.specifier + ext,
+            (isDir ? spec.specifier + "/index" : spec.specifier) + ext,
           ),
         );
       }

--- a/test/fixture/src/dir-export.ts
+++ b/test/fixture/src/dir-export.ts
@@ -1,0 +1,1 @@
+export * from "./star";

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -25,6 +25,7 @@ describe("mkdist", () => {
       [
         "dist/README.md",
         "dist/demo.css",
+        "dist/dir-export.mjs",
         "dist/foo.mjs",
         "dist/foo.d.ts", // manual
         "dist/index.mjs",
@@ -101,6 +102,8 @@ describe("mkdist", () => {
       [
         "dist/README.md",
         "dist/demo.css",
+        "dist/dir-export.d.ts",
+        "dist/dir-export.mjs",
         "dist/foo.mjs",
         "dist/foo.d.ts",
         "dist/index.mjs",
@@ -143,6 +146,11 @@ describe("mkdist", () => {
       .toMatchInlineSnapshot(`
         "export * from "./other.js";
         export type { Other } from "./other.js";
+        "
+      `);
+    expect(await readFile(resolve(rootDir, "dist/dir-export.d.ts"), "utf8"))
+      .toMatchInlineSnapshot(`
+        "export * from "./star/index.js";
         "
       `);
     expect(
@@ -201,6 +209,7 @@ describe("mkdist", () => {
         "dist/README.md",
         "dist/demo.scss",
         "dist/_base.scss",
+        "dist/dir-export.mjs",
         "dist/foo.mjs",
         "dist/foo.d.ts", // manual
         "dist/index.mjs",
@@ -441,6 +450,8 @@ describe("mkdist with vue-tsc v1", () => {
       [
         "dist/README.md",
         "dist/demo.css",
+        "dist/dir-export.d.ts",
+        "dist/dir-export.mjs",
         "dist/foo.mjs",
         "dist/foo.d.ts",
         "dist/index.mjs",
@@ -554,6 +565,8 @@ describe("mkdist with vue-tsc ~v2.0.21", () => {
       [
         "dist/README.md",
         "dist/demo.css",
+        "dist/dir-export.d.ts",
+        "dist/dir-export.mjs",
         "dist/foo.mjs",
         "dist/foo.d.ts",
         "dist/index.mjs",


### PR DESCRIPTION
resolves https://github.com/nuxt/module-builder/issues/308

with directory indices, currently we output a JS file like this:

```ts
export * from "./star/index.mjs";
```

and a declaration like this:

```ts
export * from "./star.mjs";
```

This PR normalises the DTS generation so both have `/index` appended.
