### PR TITLE
feat(vue)!: refactor vue loader with vue/compiler-sfc

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   "peerDependencies": {
     "sass": "^1.78.0",
     "typescript": ">=5.5.4",
+    "vue": "^3.2.13",
     "vue-tsc": "^1.8.27 || ^2.0.21"
   },
   "peerDependenciesMeta": {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,9 @@
     "typescript": {
       "optional": true
     },
+    "vue": {
+      "optional": true
+    },
     "vue-tsc": {
       "optional": true
     }

--- a/src/loaders/vue.ts
+++ b/src/loaders/vue.ts
@@ -8,7 +8,7 @@ import type {
 } from "../loader";
 
 import fs from "node:fs";
-import { dirname, resolve } from "pathe";
+import { basename, dirname, resolve } from "pathe";
 
 import { compileScript, parse } from "vue/compiler-sfc";
 
@@ -49,7 +49,10 @@ export function defineVueLoader(options?: DefineVueLoaderOptions): Loader {
     let fakeScriptBlock = false;
 
     const raw = await input.getContents();
-    const sfc = parse(raw, { filename: input.path, ignoreEmpty: true });
+    const sfc = parse(raw, {
+      filename: basename(input.path),
+      ignoreEmpty: true,
+    });
     if (sfc.errors.length > 0) {
       for (const error of sfc.errors) {
         console.error(error);

--- a/src/utils/vue-dts.ts
+++ b/src/utils/vue-dts.ts
@@ -38,7 +38,12 @@ export async function getVueDeclarations(
       break;
     }
     default: {
-      await emitVueTscLatest(vfs, opts.typescript.compilerOptions, srcFiles);
+      await emitVueTscLatest(
+        vfs,
+        opts.typescript.compilerOptions,
+        srcFiles,
+        opts.rootDir!,
+      );
     }
   }
 
@@ -173,6 +178,7 @@ async function emitVueTscLatest(
   vfs: Map<string, string>,
   compilerOptions: CompilerOptions,
   srcFiles: string[],
+  rootDir: string,
 ) {
   const { resolve: resolveModule } = await import("mlly");
   const ts: typeof import("typescript") = await import("typescript").then(
@@ -213,8 +219,15 @@ async function emitVueTscLatest(
       const vueLanguagePlugin = vueLanguageCore.createVueLanguagePlugin<string>(
         ts,
         options.options,
-        vueLanguageCore.resolveVueCompilerOptions({}),
-        (id) => id as string,
+        vueLanguageCore.createParsedCommandLineByJson(
+          ts,
+          ts.sys,
+          rootDir,
+          {},
+          undefined,
+          true,
+        ).vueOptions,
+        (id) => id,
       );
       return [vueLanguagePlugin];
     },

--- a/test/fixture/src/components/script-setup-ts.vue
+++ b/test/fixture/src/components/script-setup-ts.vue
@@ -4,9 +4,11 @@
 
 <script setup lang="ts">
 import { ref } from "vue";
+import { Color } from "#prop-types";
 
 const props = defineProps<{
   msg: string;
+  color: Color;
 }>();
 
 const str = ref<string | number>("hello");

--- a/test/fixture/src/prop-types/index.ts
+++ b/test/fixture/src/prop-types/index.ts
@@ -1,0 +1,5 @@
+export interface Color {
+  red: number;
+  green: number;
+  blue: number;
+}

--- a/test/fixture/tsconfig.json
+++ b/test/fixture/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "resolveJsonModule": true,
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "paths": {
+      "#prop-types": ["./src/prop-types"],
+      "#prop-types/*": ["./src/prop-types/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -625,6 +625,34 @@ describe("mkdist with vue-tsc v1", () => {
 
     expect(
       await readFile(
+        resolve(rootDir, "dist/components/script-multi-block.vue"),
+        "utf8",
+      ),
+    ).toMatchInlineSnapshot(`
+      "<script>
+      import { defineComponent as _defineComponent } from "vue";
+      export default /* @__PURE__ */ _defineComponent({
+        __name: "script-multi-block",
+        props: {
+          msg: { type: String, required: true }
+        },
+        setup(__props, { expose: __expose }) {
+          __expose();
+          const __returned__ = {};
+          Object.defineProperty(__returned__, "__isScriptSetup", { enumerable: false, value: true });
+          return __returned__;
+        }
+      });
+      </script>
+
+      <template>
+        <div>{{ msg }}</div>
+      </template>
+      "
+    `);
+
+    expect(
+      await readFile(
         resolve(rootDir, "dist/components/script-multi-block.vue.d.ts"),
         "utf8",
       ),
@@ -812,6 +840,34 @@ describe("mkdist with vue-tsc ~v2.0.21", () => {
           str: "test";
       }, {}, {}, import("vue").ComponentOptionsMixin, import("vue").ComponentOptionsMixin, {}, string, import("vue").PublicProps, Readonly<{}> & Readonly<{}>, {}, {}, {}, {}, string, import("vue").ComponentProvideOptions, true, {}, any>;
       export default _default;
+      "
+    `);
+
+    expect(
+      await readFile(
+        resolve(rootDir, "dist/components/script-multi-block.vue"),
+        "utf8",
+      ),
+    ).toMatchInlineSnapshot(`
+      "<script>
+      import { defineComponent as _defineComponent } from "vue";
+      export default /* @__PURE__ */ _defineComponent({
+        __name: "script-multi-block",
+        props: {
+          msg: { type: String, required: true }
+        },
+        setup(__props, { expose: __expose }) {
+          __expose();
+          const __returned__ = {};
+          Object.defineProperty(__returned__, "__isScriptSetup", { enumerable: false, value: true });
+          return __returned__;
+        }
+      });
+      </script>
+
+      <template>
+        <div>{{ msg }}</div>
+      </template>
       "
     `);
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -122,6 +122,7 @@ describe("mkdist", () => {
         "dist/components/index.mjs",
         "dist/components/index.d.ts",
         "dist/components/blank.vue",
+        "dist/components/blank.vue.d.ts",
         "dist/components/js.vue",
         "dist/components/js.vue.d.ts",
         "dist/components/script-multi-block.vue",
@@ -189,6 +190,17 @@ describe("mkdist", () => {
           test: string;
           str: "test";
       }, {}, {}, import("vue").ComponentOptionsMixin, import("vue").ComponentOptionsMixin, {}, string, import("vue").PublicProps, Readonly<{}> & Readonly<{}>, {}, {}, {}, {}, string, import("vue").ComponentProvideOptions, true, {}, any>;
+      export default _default;
+      "
+    `);
+
+    expect(
+      await readFile(
+        resolve(rootDir, "dist/components/blank.vue.d.ts"),
+        "utf8",
+      ),
+    ).toMatchInlineSnapshot(`
+      "declare const _default: import("vue").DefineComponent<{}, {}, {}, {}, {}, import("vue").ComponentOptionsMixin, import("vue").ComponentOptionsMixin, {}, string, import("vue").PublicProps, Readonly<{}> & Readonly<{}>, {}, {}, {}, {}, string, import("vue").ComponentProvideOptions, true, {}, any>;
       export default _default;
       "
     `);
@@ -537,6 +549,7 @@ describe("mkdist with vue-tsc v1", () => {
         "dist/components/index.mjs",
         "dist/components/index.d.ts",
         "dist/components/blank.vue",
+        "dist/components/blank.vue.d.ts",
         "dist/components/js.vue",
         "dist/components/js.vue.d.ts",
         "dist/components/script-multi-block.vue",
@@ -586,6 +599,17 @@ describe("mkdist with vue-tsc v1", () => {
       export * as scriptSetupTS from "./script-setup-ts.vue.js";
       export * as scriptMultiBlock from "./script-multi-block.vue.js";
       export * as ts from "./ts.vue.js";
+      "
+    `);
+
+    expect(
+      await readFile(
+        resolve(rootDir, "dist/components/blank.vue.d.ts"),
+        "utf8",
+      ),
+    ).toMatchInlineSnapshot(`
+      "declare const _default: import("vue").DefineComponent<{}, {}, {}, {}, {}, import("vue").ComponentOptionsMixin, import("vue").ComponentOptionsMixin, {}, string, import("vue").PublicProps, Readonly<{}> & Readonly<{}>, {}, {}, {}, {}, string, import("vue").ComponentProvideOptions, true, {}, any>;
+      export default _default;
       "
     `);
 
@@ -717,6 +741,7 @@ describe("mkdist with vue-tsc ~v2.0.21", () => {
         "dist/components/index.mjs",
         "dist/components/index.d.ts",
         "dist/components/blank.vue",
+        "dist/components/blank.vue.d.ts",
         "dist/components/js.vue",
         "dist/components/js.vue.d.ts",
         "dist/components/script-multi-block.vue",
@@ -766,6 +791,17 @@ describe("mkdist with vue-tsc ~v2.0.21", () => {
       export * as scriptSetupTS from "./script-setup-ts.vue.js";
       export * as scriptMultiBlock from "./script-multi-block.vue.js";
       export * as ts from "./ts.vue.js";
+      "
+    `);
+
+    expect(
+      await readFile(
+        resolve(rootDir, "dist/components/blank.vue.d.ts"),
+        "utf8",
+      ),
+    ).toMatchInlineSnapshot(`
+      "declare const _default: import("vue").DefineComponent<{}, {}, {}, {}, {}, import("vue").ComponentOptionsMixin, import("vue").ComponentOptionsMixin, {}, string, import("vue").PublicProps, Readonly<{}> & Readonly<{}>, {}, {}, {}, {}, string, import("vue").ComponentProvideOptions, true, {}, any>;
+      export default _default;
       "
     `);
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -192,6 +192,53 @@ describe("mkdist", () => {
       export default _default;
       "
     `);
+
+    expect(
+      await readFile(
+        resolve(rootDir, "dist/components/script-multi-block.vue.d.ts"),
+        "utf8",
+      ),
+    ).toMatchInlineSnapshot(`
+      "interface MyComponentProps {
+          msg: string;
+      }
+      declare const _default: import("vue").DefineComponent<import("vue").ExtractPropTypes<__VLS_TypePropsToOption<MyComponentProps>>, {}, {}, {}, {}, import("vue").ComponentOptionsMixin, import("vue").ComponentOptionsMixin, {}, string, import("vue").PublicProps, Readonly<import("vue").ExtractPropTypes<__VLS_TypePropsToOption<MyComponentProps>>> & Readonly<{}>, {}, {}, {}, {}, string, import("vue").ComponentProvideOptions, true, {}, any>;
+      export default _default;
+      type __VLS_NonUndefinedable<T> = T extends undefined ? never : T;
+      type __VLS_TypePropsToOption<T> = {
+          [K in keyof T]-?: {} extends Pick<T, K> ? {
+              type: import('vue').PropType<__VLS_NonUndefinedable<T[K]>>;
+          } : {
+              type: import('vue').PropType<T[K]>;
+              required: true;
+          };
+      };
+      "
+    `);
+
+    expect(
+      await readFile(
+        resolve(rootDir, "dist/components/script-setup-ts.vue.d.ts"),
+        "utf8",
+      ),
+    ).toMatchInlineSnapshot(`
+      "declare const _default: import("vue").DefineComponent<import("vue").ExtractPropTypes<__VLS_TypePropsToOption<{
+          msg: string;
+      }>>, {}, {}, {}, {}, import("vue").ComponentOptionsMixin, import("vue").ComponentOptionsMixin, {}, string, import("vue").PublicProps, Readonly<import("vue").ExtractPropTypes<__VLS_TypePropsToOption<{
+          msg: string;
+      }>>> & Readonly<{}>, {}, {}, {}, {}, string, import("vue").ComponentProvideOptions, true, {}, any>;
+      export default _default;
+      type __VLS_NonUndefinedable<T> = T extends undefined ? never : T;
+      type __VLS_TypePropsToOption<T> = {
+          [K in keyof T]-?: {} extends Pick<T, K> ? {
+              type: import('vue').PropType<__VLS_NonUndefinedable<T[K]>>;
+          } : {
+              type: import('vue').PropType<T[K]>;
+              required: true;
+          };
+      };
+      "
+    `);
   }, 50_000);
 
   describe("mkdist (sass compilation)", () => {
@@ -552,6 +599,53 @@ describe("mkdist with vue-tsc v1", () => {
       export default _default;
       "
     `);
+
+    expect(
+      await readFile(
+        resolve(rootDir, "dist/components/script-multi-block.vue.d.ts"),
+        "utf8",
+      ),
+    ).toMatchInlineSnapshot(`
+      "interface MyComponentProps {
+          msg: string;
+      }
+      declare const _default: import("vue").DefineComponent<import("vue").ExtractPropTypes<__VLS_TypePropsToRuntimeProps<MyComponentProps>>, {}, {}, {}, {}, import("vue").ComponentOptionsMixin, import("vue").ComponentOptionsMixin, {}, string, import("vue").PublicProps, Readonly<import("vue").ExtractPropTypes<__VLS_TypePropsToRuntimeProps<MyComponentProps>>> & Readonly<{}>, {}, {}, {}, {}, string, import("vue").ComponentProvideOptions, true, {}, any>;
+      export default _default;
+      type __VLS_NonUndefinedable<T> = T extends undefined ? never : T;
+      type __VLS_TypePropsToRuntimeProps<T> = {
+          [K in keyof T]-?: {} extends Pick<T, K> ? {
+              type: import('vue').PropType<__VLS_NonUndefinedable<T[K]>>;
+          } : {
+              type: import('vue').PropType<T[K]>;
+              required: true;
+          };
+      };
+      "
+    `);
+
+    expect(
+      await readFile(
+        resolve(rootDir, "dist/components/script-setup-ts.vue.d.ts"),
+        "utf8",
+      ),
+    ).toMatchInlineSnapshot(`
+      "declare const _default: import("vue").DefineComponent<import("vue").ExtractPropTypes<__VLS_TypePropsToRuntimeProps<{
+          msg: string;
+      }>>, {}, {}, {}, {}, import("vue").ComponentOptionsMixin, import("vue").ComponentOptionsMixin, {}, string, import("vue").PublicProps, Readonly<import("vue").ExtractPropTypes<__VLS_TypePropsToRuntimeProps<{
+          msg: string;
+      }>>> & Readonly<{}>, {}, {}, {}, {}, string, import("vue").ComponentProvideOptions, true, {}, any>;
+      export default _default;
+      type __VLS_NonUndefinedable<T> = T extends undefined ? never : T;
+      type __VLS_TypePropsToRuntimeProps<T> = {
+          [K in keyof T]-?: {} extends Pick<T, K> ? {
+              type: import('vue').PropType<__VLS_NonUndefinedable<T[K]>>;
+          } : {
+              type: import('vue').PropType<T[K]>;
+              required: true;
+          };
+      };
+      "
+    `);
   }, 50_000);
 });
 
@@ -683,6 +777,53 @@ describe("mkdist with vue-tsc ~v2.0.21", () => {
           str: "test";
       }, {}, {}, import("vue").ComponentOptionsMixin, import("vue").ComponentOptionsMixin, {}, string, import("vue").PublicProps, Readonly<{}> & Readonly<{}>, {}, {}, {}, {}, string, import("vue").ComponentProvideOptions, true, {}, any>;
       export default _default;
+      "
+    `);
+
+    expect(
+      await readFile(
+        resolve(rootDir, "dist/components/script-multi-block.vue.d.ts"),
+        "utf8",
+      ),
+    ).toMatchInlineSnapshot(`
+      "interface MyComponentProps {
+          msg: string;
+      }
+      declare const _default: import("vue").DefineComponent<import("vue").ExtractPropTypes<__VLS_TypePropsToOption<MyComponentProps>>, {}, {}, {}, {}, import("vue").ComponentOptionsMixin, import("vue").ComponentOptionsMixin, {}, string, import("vue").PublicProps, Readonly<import("vue").ExtractPropTypes<__VLS_TypePropsToOption<MyComponentProps>>> & Readonly<{}>, {}, {}, {}, {}, string, import("vue").ComponentProvideOptions, true, {}, any>;
+      export default _default;
+      type __VLS_NonUndefinedable<T> = T extends undefined ? never : T;
+      type __VLS_TypePropsToOption<T> = {
+          [K in keyof T]-?: {} extends Pick<T, K> ? {
+              type: import('vue').PropType<__VLS_NonUndefinedable<T[K]>>;
+          } : {
+              type: import('vue').PropType<T[K]>;
+              required: true;
+          };
+      };
+      "
+    `);
+
+    expect(
+      await readFile(
+        resolve(rootDir, "dist/components/script-setup-ts.vue.d.ts"),
+        "utf8",
+      ),
+    ).toMatchInlineSnapshot(`
+      "declare const _default: import("vue").DefineComponent<import("vue").ExtractPropTypes<__VLS_TypePropsToOption<{
+          msg: string;
+      }>>, {}, {}, {}, {}, import("vue").ComponentOptionsMixin, import("vue").ComponentOptionsMixin, {}, string, import("vue").PublicProps, Readonly<import("vue").ExtractPropTypes<__VLS_TypePropsToOption<{
+          msg: string;
+      }>>> & Readonly<{}>, {}, {}, {}, {}, string, import("vue").ComponentProvideOptions, true, {}, any>;
+      export default _default;
+      type __VLS_NonUndefinedable<T> = T extends undefined ? never : T;
+      type __VLS_TypePropsToOption<T> = {
+          [K in keyof T]-?: {} extends Pick<T, K> ? {
+              type: import('vue').PropType<__VLS_NonUndefinedable<T[K]>>;
+          } : {
+              type: import('vue').PropType<T[K]>;
+              required: true;
+          };
+      };
       "
     `);
   }, 50_000);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -125,7 +125,9 @@ describe("mkdist", () => {
         "dist/components/js.vue",
         "dist/components/js.vue.d.ts",
         "dist/components/script-multi-block.vue",
+        "dist/components/script-multi-block.vue.d.ts",
         "dist/components/script-setup-ts.vue",
+        "dist/components/script-setup-ts.vue.d.ts",
         "dist/components/ts.vue",
         "dist/components/ts.vue.d.ts",
         "dist/components/jsx.mjs",
@@ -293,7 +295,7 @@ describe("mkdist", () => {
         path: "test.vue",
       });
       expect(results).toMatchObject([
-        { contents: ["<script foo>", "Test;", "</script>"].join("\n") },
+        { contents: ["<script foo>", "Test;", "</script>", ""].join("\n") },
       ]);
     });
 
@@ -304,32 +306,28 @@ describe("mkdist", () => {
       const results = await loadFile({
         extension: ".vue",
         getContents: () =>
-          '<style scoped lang="scss">$color: red; :root { background-color: $color }</style>',
+          [
+            "<script>export default {}</script>",
+            '<style scoped lang="scss">$color: red; :root { background-color: $color }</style>',
+          ].join("\n"),
         path: "test.vue",
       });
       expect(results).toMatchObject([
         {
           contents: [
+            "<script>",
+            "export default {}",
+            "</script>",
+            "",
             "<style scoped>",
             ":root {",
             "  background-color: red;",
             "}",
             "</style>",
+            "",
           ].join("\n"),
         },
       ]);
-    });
-
-    it("vueLoader bypass <script setup>", async () => {
-      const { loadFile } = createLoader({
-        loaders: ["vue", "js"],
-      });
-      const results = await loadFile({
-        extension: ".vue",
-        getContents: () => '<script lang="ts" setup>Test</script>',
-        path: "test.vue",
-      });
-      expect(results).toMatchObject([{ raw: true }]);
     });
 
     it("vueLoader will generate dts file", async () => {
@@ -495,7 +493,9 @@ describe("mkdist with vue-tsc v1", () => {
         "dist/components/js.vue",
         "dist/components/js.vue.d.ts",
         "dist/components/script-multi-block.vue",
+        "dist/components/script-multi-block.vue.d.ts",
         "dist/components/script-setup-ts.vue",
+        "dist/components/script-setup-ts.vue.d.ts",
         "dist/components/ts.vue",
         "dist/components/ts.vue.d.ts",
         "dist/components/jsx.mjs",
@@ -626,7 +626,9 @@ describe("mkdist with vue-tsc ~v2.0.21", () => {
         "dist/components/js.vue",
         "dist/components/js.vue.d.ts",
         "dist/components/script-multi-block.vue",
+        "dist/components/script-multi-block.vue.d.ts",
         "dist/components/script-setup-ts.vue",
+        "dist/components/script-setup-ts.vue.d.ts",
         "dist/components/ts.vue",
         "dist/components/ts.vue.d.ts",
         "dist/components/jsx.mjs",
@@ -681,28 +683,6 @@ describe("mkdist with vue-tsc ~v2.0.21", () => {
           str: "test";
       }, {}, {}, import("vue").ComponentOptionsMixin, import("vue").ComponentOptionsMixin, {}, string, import("vue").PublicProps, Readonly<{}> & Readonly<{}>, {}, {}, {}, {}, string, import("vue").ComponentProvideOptions, true, {}, any>;
       export default _default;
-      "
-    `);
-
-    expect(
-      await readFile(
-        resolve(rootDir, "dist/components/script-multi-block.vue"),
-        "utf8",
-      ),
-    ).toMatchInlineSnapshot(`
-      "<template>
-        <div>{{ msg }}</div>
-      </template>
-
-      <script lang="ts">
-      interface MyComponentProps {
-        msg: string;
-      }
-      </script>
-
-      <script setup lang="ts">
-      defineProps<MyComponentProps>();
-      </script>
       "
     `);
   }, 50_000);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -46,6 +46,7 @@ describe("mkdist", () => {
         "dist/ts/test1.mjs",
         "dist/ts/test2.mjs",
         "dist/nested.css",
+        "dist/prop-types/index.mjs",
       ]
         .map((f) => resolve(rootDir, f))
         .sort(),
@@ -144,6 +145,8 @@ describe("mkdist", () => {
         "dist/ts/test1.d.mts",
         "dist/ts/test2.d.cts",
         "dist/nested.css",
+        "dist/prop-types/index.mjs",
+        "dist/prop-types/index.d.ts",
       ]
         .map((f) => resolve(rootDir, f))
         .sort(),
@@ -234,8 +237,10 @@ describe("mkdist", () => {
         "utf8",
       ),
     ).toMatchInlineSnapshot(`
-      "type __VLS_Props = {
+      "import { Color } from "#prop-types";
+      type __VLS_Props = {
           msg: string;
+          color: Color;
       };
       declare const _default: import("vue").DefineComponent<import("vue").ExtractPropTypes<__VLS_TypePropsToOption<__VLS_Props>>, {}, {}, {}, {}, import("vue").ComponentOptionsMixin, import("vue").ComponentOptionsMixin, {}, string, import("vue").PublicProps, Readonly<import("vue").ExtractPropTypes<__VLS_TypePropsToOption<__VLS_Props>>> & Readonly<{}>, {}, {}, {}, {}, string, import("vue").ComponentProvideOptions, true, {}, any>;
       export default _default;
@@ -314,6 +319,7 @@ describe("mkdist", () => {
         "dist/ts/test1.mjs",
         "dist/ts/test2.mjs",
         "dist/nested.css",
+        "dist/prop-types/index.mjs",
       ]
         .map((f) => resolve(rootDir, f))
         .sort(),
@@ -570,6 +576,8 @@ describe("mkdist with vue-tsc v1", () => {
         "dist/ts/test1.d.mts",
         "dist/ts/test2.d.cts",
         "dist/nested.css",
+        "dist/prop-types/index.mjs",
+        "dist/prop-types/index.d.ts",
       ]
         .map((f) => resolve(rootDir, f))
         .sort(),
@@ -620,6 +628,38 @@ describe("mkdist with vue-tsc v1", () => {
           str: "test";
       }, {}, {}, import("vue").ComponentOptionsMixin, import("vue").ComponentOptionsMixin, {}, string, import("vue").PublicProps, Readonly<{}> & Readonly<{}>, {}, {}, {}, {}, string, import("vue").ComponentProvideOptions, true, {}, any>;
       export default _default;
+      "
+    `);
+
+    expect(
+      await readFile(
+        resolve(rootDir, "dist/components/script-setup-ts.vue"),
+        "utf8",
+      ),
+    ).toMatchInlineSnapshot(`
+      "<script>
+      import { defineComponent as _defineComponent } from "vue";
+      import { ref } from "vue";
+      export default /* @__PURE__ */ _defineComponent({
+        __name: "script-setup-ts",
+        props: {
+          msg: { type: String, required: true },
+          color: { type: Object, required: true }
+        },
+        setup(__props, { expose: __expose }) {
+          __expose();
+          const props = __props;
+          const str = ref("hello");
+          const __returned__ = { props, str };
+          Object.defineProperty(__returned__, "__isScriptSetup", { enumerable: false, value: true });
+          return __returned__;
+        }
+      });
+      </script>
+
+      <template>
+        <div>{{ str }}</div>
+      </template>
       "
     `);
 
@@ -680,10 +720,13 @@ describe("mkdist with vue-tsc v1", () => {
         "utf8",
       ),
     ).toMatchInlineSnapshot(`
-      "declare const _default: import("vue").DefineComponent<import("vue").ExtractPropTypes<__VLS_TypePropsToRuntimeProps<{
+      "import { Color } from "#prop-types";
+      declare const _default: import("vue").DefineComponent<import("vue").ExtractPropTypes<__VLS_TypePropsToRuntimeProps<{
           msg: string;
+          color: Color;
       }>>, {}, {}, {}, {}, import("vue").ComponentOptionsMixin, import("vue").ComponentOptionsMixin, {}, string, import("vue").PublicProps, Readonly<import("vue").ExtractPropTypes<__VLS_TypePropsToRuntimeProps<{
           msg: string;
+          color: Color;
       }>>> & Readonly<{}>, {}, {}, {}, {}, string, import("vue").ComponentProvideOptions, true, {}, any>;
       export default _default;
       type __VLS_NonUndefinedable<T> = T extends undefined ? never : T;
@@ -790,6 +833,8 @@ describe("mkdist with vue-tsc ~v2.0.21", () => {
         "dist/ts/test1.d.mts",
         "dist/ts/test2.d.cts",
         "dist/nested.css",
+        "dist/prop-types/index.mjs",
+        "dist/prop-types/index.d.ts",
       ]
         .map((f) => resolve(rootDir, f))
         .sort(),
@@ -900,10 +945,13 @@ describe("mkdist with vue-tsc ~v2.0.21", () => {
         "utf8",
       ),
     ).toMatchInlineSnapshot(`
-      "declare const _default: import("vue").DefineComponent<import("vue").ExtractPropTypes<__VLS_TypePropsToOption<{
+      "import { Color } from "#prop-types";
+      declare const _default: import("vue").DefineComponent<import("vue").ExtractPropTypes<__VLS_TypePropsToOption<{
           msg: string;
+          color: Color;
       }>>, {}, {}, {}, {}, import("vue").ComponentOptionsMixin, import("vue").ComponentOptionsMixin, {}, string, import("vue").PublicProps, Readonly<import("vue").ExtractPropTypes<__VLS_TypePropsToOption<{
           msg: string;
+          color: Color;
       }>>> & Readonly<{}>, {}, {}, {}, {}, string, import("vue").ComponentProvideOptions, true, {}, any>;
       export default _default;
       type __VLS_NonUndefinedable<T> = T extends undefined ? never : T;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -234,11 +234,10 @@ describe("mkdist", () => {
         "utf8",
       ),
     ).toMatchInlineSnapshot(`
-      "declare const _default: import("vue").DefineComponent<import("vue").ExtractPropTypes<__VLS_TypePropsToOption<{
+      "type __VLS_Props = {
           msg: string;
-      }>>, {}, {}, {}, {}, import("vue").ComponentOptionsMixin, import("vue").ComponentOptionsMixin, {}, string, import("vue").PublicProps, Readonly<import("vue").ExtractPropTypes<__VLS_TypePropsToOption<{
-          msg: string;
-      }>>> & Readonly<{}>, {}, {}, {}, {}, string, import("vue").ComponentProvideOptions, true, {}, any>;
+      };
+      declare const _default: import("vue").DefineComponent<import("vue").ExtractPropTypes<__VLS_TypePropsToOption<__VLS_Props>>, {}, {}, {}, {}, import("vue").ComponentOptionsMixin, import("vue").ComponentOptionsMixin, {}, string, import("vue").PublicProps, Readonly<import("vue").ExtractPropTypes<__VLS_TypePropsToOption<__VLS_Props>>> & Readonly<{}>, {}, {}, {}, {}, string, import("vue").ComponentProvideOptions, true, {}, any>;
       export default _default;
       type __VLS_NonUndefinedable<T> = T extends undefined ? never : T;
       type __VLS_TypePropsToOption<T> = {


### PR DESCRIPTION
Refactor the vue loader with vue/compiler-sfc.

Resolve #209 #249 #243 #14 #15 
Close #210 

Some break changes:
- Since there is no effective way to confirm the position of blocks, all blocks will be reordered after build. (unless it can be quick return)
- The script blocks will look a little (?) different from source if developer uses `<script setup lang="*">`, but they are still human readable
- see https://github.com/unjs/mkdist/pull/251#discussion_r1827009276

But I think it is worth.

also updated test.

------

~~It is a draft pull request because I found some times `vue-tsc^2.1.0` will add the vue global declare in dts output for no resaon.~~

~~It happens in my own package [Teages/mkdist-vue-loader](https://github.com/Teages/mkdist-vue-loader) but after I merged back to mkdist it disappeared....~~

fixed with https://github.com/unjs/mkdist/pull/251/commits/31e93f077e31fa32ba3caa3081cc4d321a4abc78

tested with https://github.com/unjs/mkdist/pull/251/commits/2452db9dda81d00dd61214f1ad8592959b6c4f6d
