### PR TITLE
fix: scan dotfiles in source paths

### DIFF
--- a/src/make.ts
+++ b/src/make.ts
@@ -44,8 +44,12 @@ export async function mkdist(
   }
 
   // Scan input files
+  const ignored = await fsp.readFile(resolve(options.rootDir, ".gitignore"), "utf8")
+    .then((r) => r.split("\n").map(r => r.trim()).filter(r => r && !r.startsWith("#")))
+    .catch(() => []);
   const filePaths = await glob(options.pattern || "**", {
     absolute: false,
+    ignore: ignored,
     cwd: options.srcDir,
     dot: true,
   });

--- a/src/make.ts
+++ b/src/make.ts
@@ -47,6 +47,7 @@ export async function mkdist(
   const filePaths = await glob(options.pattern || "**", {
     absolute: false,
     cwd: options.srcDir,
+    dot: true,
   });
 
   const files: InputFile[] = filePaths.map((path) => {

--- a/src/make.ts
+++ b/src/make.ts
@@ -44,8 +44,14 @@ export async function mkdist(
   }
 
   // Scan input files
-  const ignored = await fsp.readFile(resolve(options.rootDir, ".gitignore"), "utf8")
-    .then((r) => r.split("\n").map(r => r.trim()).filter(r => r && !r.startsWith("#")))
+  const ignored = await fsp
+    .readFile(resolve(options.rootDir, ".gitignore"), "utf8")
+    .then((r) =>
+      r
+        .split("\n")
+        .map((r) => r.trim())
+        .filter((r) => r && !r.startsWith("#")),
+    )
     .catch(() => []);
   const filePaths = await glob(options.pattern || "**", {
     absolute: false,


### PR DESCRIPTION
resolves https://github.com/nuxt/module-builder/issues/400

Might be worth more discussion about whether this is desired, or a breaking change.

(Nevertheless it should be possible to override by using an array pattern syntax to exclude files matching a dot pattern. Alternatively, we could allow configuring glob options more specifically - but it feels like the pattern syntax is a safer API.)