### PR TITLE
fix: convert absolute gitignore patterns to relative

### DIFF
--- a/src/make.ts
+++ b/src/make.ts
@@ -51,7 +51,7 @@ export async function mkdist(
         .split("\n")
         .map((r) => r.trim())
         .filter((r) => r && !r.startsWith("#"))
-        .map(r => r.startsWith("/") ? r.slice(1) : r),
+        .map((r) => (r.startsWith("/") ? r.slice(1) : r)),
     )
     .catch(() => []);
   const filePaths = await glob(options.pattern || "**", {

--- a/src/make.ts
+++ b/src/make.ts
@@ -50,7 +50,8 @@ export async function mkdist(
       r
         .split("\n")
         .map((r) => r.trim())
-        .filter((r) => r && !r.startsWith("#")),
+        .filter((r) => r && !r.startsWith("#"))
+        .map(r => r.startsWith("/") ? r.slice(1) : r),
     )
     .catch(() => []);
   const filePaths = await glob(options.pattern || "**", {

--- a/src/make.ts
+++ b/src/make.ts
@@ -51,6 +51,8 @@ export async function mkdist(
         .split("\n")
         .map((r) => r.trim())
         .filter((r) => r && !r.startsWith("#"))
+        // Gitignore => Glob
+        // TODO: Handle !negate and * => ** conversion 
         .map((r) => (r.startsWith("/") ? r.slice(1) : r)),
     )
     .catch(() => []);

--- a/src/make.ts
+++ b/src/make.ts
@@ -52,7 +52,7 @@ export async function mkdist(
         .map((r) => r.trim())
         .filter((r) => r && !r.startsWith("#"))
         // Gitignore => Glob
-        // TODO: Handle !negate and * => ** conversion
+        // TODO: https://github.com/unjs/mkdist/issues/271
         .map((r) => (r.startsWith("/") ? r.slice(1) : r)),
     )
     .catch(() => []);

--- a/src/make.ts
+++ b/src/make.ts
@@ -52,7 +52,7 @@ export async function mkdist(
         .map((r) => r.trim())
         .filter((r) => r && !r.startsWith("#"))
         // Gitignore => Glob
-        // TODO: Handle !negate and * => ** conversion 
+        // TODO: Handle !negate and * => ** conversion
         .map((r) => (r.startsWith("/") ? r.slice(1) : r)),
     )
     .catch(() => []);


### PR DESCRIPTION
repro: https://github.com/unjs/unstorage/pull/523

With #253, we started to scan dotfiles and ignore git ignored paths however it makes issues since globby accepts globs `/path` means absolute path in gitignore `/path` means `<gitDir>/path`.