### PR TITLE
fix!: declaration extensions should correspond to their js extension

### DIFF
--- a/src/loaders/js.ts
+++ b/src/loaders/js.ts
@@ -7,6 +7,7 @@ const DECLARATION_RE = /\.d\.[cm]?ts$/;
 const CM_LETTER_RE = /(?<=\.)(c|m)(?=[jt]s$)/;
 
 const KNOWN_EXT_RE = /\.(c|m)?[jt]sx?$/;
+const VUE_EXT_RE = /\.vue\.[jt]s$/;
 
 const TS_EXTS = new Set([".ts", ".mts", ".cts"]);
 
@@ -19,15 +20,23 @@ export const jsLoader: Loader = async (input, { options }) => {
 
   let contents = await input.getContents();
 
+  const isCjs = options.format === "cjs";
+  let extension = isCjs ? ".js" : ".mjs"; // TODO: Default to .cjs in next major version
+  if (options.ext) {
+    extension = options.ext.startsWith(".") ? options.ext : `.${options.ext}`;
+  }
+
   // declaration
   if (options.declaration && !input.srcPath?.match(DECLARATION_RE)) {
-    const cm = input.srcPath?.match(CM_LETTER_RE)?.[0] || "";
-    const extension = `.d.${cm}ts`;
+    const cm = extension.match(CM_LETTER_RE)?.[0] || "";
+    // Vue files always create .vue.d.ts declarations
+    // No matter what the corresponding js file uses as an extension
+    const isVue = VUE_EXT_RE.test(input.path);
     output.push({
       contents,
       srcPath: input.srcPath,
       path: input.path,
-      extension,
+      extension: isVue ? ".d.ts" : `.d.${cm}ts`,
       declaration: true,
     });
   }
@@ -46,18 +55,12 @@ export const jsLoader: Loader = async (input, { options }) => {
   }
 
   // esm => cjs
-  const isCjs = options.format === "cjs";
   if (isCjs) {
     contents = jiti("")
       .transform({ source: contents, retainLines: false })
       .replace(/^exports.default = /gm, "module.exports = ")
       .replace(/^var _default = exports.default = /gm, "module.exports = ")
       .replace("module.exports = void 0;", "");
-  }
-
-  let extension = isCjs ? ".js" : ".mjs"; // TODO: Default to .cjs in next major version
-  if (options.ext) {
-    extension = options.ext.startsWith(".") ? options.ext : `.${options.ext}`;
   }
 
   output.push({

--- a/src/loaders/js.ts
+++ b/src/loaders/js.ts
@@ -21,9 +21,13 @@ export const jsLoader: Loader = async (input, { options }) => {
   let contents = await input.getContents();
 
   const isCjs = options.format === "cjs";
-  
+
   // TODO: Default to .cjs in next major version
-  const extension = options.ext ? withLeadingDot(options.ext) : (isCjs ? ".js" : ".mjs");
+  const extension = options.ext
+    ? withLeadingDot(options.ext)
+    : isCjs
+      ? ".js"
+      : ".mjs";
 
   // declaration
   if (options.declaration && !input.srcPath?.match(DECLARATION_RE)) {
@@ -71,6 +75,6 @@ export const jsLoader: Loader = async (input, { options }) => {
   return output;
 };
 
-function withLeadingDot (ext: string) {
+function withLeadingDot(ext: string) {
   return ext.startsWith(".") ? ext : `.${ext}`;
 }

--- a/src/loaders/js.ts
+++ b/src/loaders/js.ts
@@ -21,13 +21,12 @@ export const jsLoader: Loader = async (input, { options }) => {
   let contents = await input.getContents();
 
   const isCjs = options.format === "cjs";
+  const defaultExtension = isCjs ? ".cjs" : ".mjs";
 
   // TODO: Default to .cjs in next major version
   const extension = options.ext
     ? withLeadingDot(options.ext)
-    : isCjs
-      ? ".js"
-      : ".mjs";
+    : defaultExtension;
 
   // declaration
   if (options.declaration && !input.srcPath?.match(DECLARATION_RE)) {

--- a/src/loaders/js.ts
+++ b/src/loaders/js.ts
@@ -21,10 +21,9 @@ export const jsLoader: Loader = async (input, { options }) => {
   let contents = await input.getContents();
 
   const isCjs = options.format === "cjs";
-  let extension = isCjs ? ".js" : ".mjs"; // TODO: Default to .cjs in next major version
-  if (options.ext) {
-    extension = options.ext.startsWith(".") ? options.ext : `.${options.ext}`;
-  }
+  
+  // TODO: Default to .cjs in next major version
+  const extension = options.ext ? withLeadingDot(options.ext) : (isCjs ? ".js" : ".mjs");
 
   // declaration
   if (options.declaration && !input.srcPath?.match(DECLARATION_RE)) {
@@ -71,3 +70,7 @@ export const jsLoader: Loader = async (input, { options }) => {
 
   return output;
 };
+
+function withLeadingDot (ext: string) {
+  return ext.startsWith(".") ? ext : `.${ext}`;
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -106,22 +106,23 @@ describe("mkdist", () => {
     expect(writtenFiles.sort()).toEqual(
       [
         "dist/README.md",
-        "dist/bar.d.ts",
+        "dist/bar.d.mts",
         "dist/bar.mjs",
         "dist/demo.css",
-        "dist/dir-export.d.ts",
+        "dist/dir-export.d.mts",
         "dist/dir-export.mjs",
         "dist/foo.mjs",
         "dist/foo.d.ts",
+        "dist/foo.d.mts",
         "dist/index.mjs",
-        "dist/index.d.ts",
+        "dist/index.d.mts",
         "dist/star/index.mjs",
-        "dist/star/index.d.ts",
+        "dist/star/index.d.mts",
         "dist/star/other.mjs",
-        "dist/star/other.d.ts",
+        "dist/star/other.d.mts",
         "dist/types.d.ts",
         "dist/components/index.mjs",
-        "dist/components/index.d.ts",
+        "dist/components/index.d.mts",
         "dist/components/blank.vue",
         "dist/components/blank.vue.d.ts",
         "dist/components/js.vue",
@@ -134,19 +135,19 @@ describe("mkdist", () => {
         "dist/components/ts.vue.d.ts",
         "dist/components/jsx.mjs",
         "dist/components/tsx.mjs",
-        "dist/components/jsx.d.ts",
-        "dist/components/tsx.d.ts",
+        "dist/components/jsx.d.mts",
+        "dist/components/tsx.d.mts",
         "dist/bar/index.mjs",
-        "dist/bar/index.d.ts",
+        "dist/bar/index.d.mts",
         "dist/bar/esm.mjs",
         "dist/bar/esm.d.mts",
         "dist/ts/test1.mjs",
         "dist/ts/test2.mjs",
         "dist/ts/test1.d.mts",
-        "dist/ts/test2.d.cts",
+        "dist/ts/test2.d.mts",
         "dist/nested.css",
         "dist/prop-types/index.mjs",
-        "dist/prop-types/index.d.ts",
+        "dist/prop-types/index.d.mts",
       ]
         .map((f) => resolve(rootDir, f))
         .sort(),
@@ -156,7 +157,7 @@ describe("mkdist", () => {
       "manual declaration",
     );
 
-    expect(await readFile(resolve(rootDir, "dist/star/index.d.ts"), "utf8"))
+    expect(await readFile(resolve(rootDir, "dist/star/index.d.mts"), "utf8"))
       .toMatchInlineSnapshot(`
         "export * from "./other.js";
         export type { Other } from "./other.js";
@@ -164,7 +165,7 @@ describe("mkdist", () => {
         "
       `);
 
-    expect(await readFile(resolve(rootDir, "dist/dir-export.d.ts"), "utf8"))
+    expect(await readFile(resolve(rootDir, "dist/dir-export.d.mts"), "utf8"))
       .toMatchInlineSnapshot(`
         "export { default as bar } from "./bar.js";
         export * from "./star/index.js";
@@ -176,7 +177,7 @@ describe("mkdist", () => {
     ).toMatch("declare");
 
     expect(
-      await readFile(resolve(rootDir, "dist/components/index.d.ts"), "utf8"),
+      await readFile(resolve(rootDir, "dist/components/index.d.mts"), "utf8"),
     ).toMatchInlineSnapshot(`
       "export * as jsx from "./jsx.jsx.js";
       export * as tsx from "./tsx.tsx.js";
@@ -497,8 +498,8 @@ describe("mkdist", () => {
     const files = errors.map((e) => relative(rootDir, e.filename));
     expect(files.sort()).toMatchInlineSnapshot(`
       [
-        "dist/components/index.d.ts",
-        "dist/components/tsx.d.ts",
+        "dist/components/index.d.mts",
+        "dist/components/tsx.d.mts",
       ]
     `);
   }, 50_000);
@@ -542,22 +543,23 @@ describe("mkdist with vue-tsc v1", () => {
     expect(writtenFiles.sort()).toEqual(
       [
         "dist/README.md",
-        "dist/bar.d.ts",
+        "dist/bar.d.mts",
         "dist/bar.mjs",
         "dist/demo.css",
-        "dist/dir-export.d.ts",
+        "dist/dir-export.d.mts",
         "dist/dir-export.mjs",
         "dist/foo.mjs",
         "dist/foo.d.ts",
+        "dist/foo.d.mts",
         "dist/index.mjs",
-        "dist/index.d.ts",
+        "dist/index.d.mts",
         "dist/star/index.mjs",
-        "dist/star/index.d.ts",
+        "dist/star/index.d.mts",
         "dist/star/other.mjs",
-        "dist/star/other.d.ts",
+        "dist/star/other.d.mts",
         "dist/types.d.ts",
         "dist/components/index.mjs",
-        "dist/components/index.d.ts",
+        "dist/components/index.d.mts",
         "dist/components/blank.vue",
         "dist/components/blank.vue.d.ts",
         "dist/components/js.vue",
@@ -570,19 +572,19 @@ describe("mkdist with vue-tsc v1", () => {
         "dist/components/ts.vue.d.ts",
         "dist/components/jsx.mjs",
         "dist/components/tsx.mjs",
-        "dist/components/jsx.d.ts",
-        "dist/components/tsx.d.ts",
+        "dist/components/jsx.d.mts",
+        "dist/components/tsx.d.mts",
         "dist/bar/index.mjs",
-        "dist/bar/index.d.ts",
+        "dist/bar/index.d.mts",
         "dist/bar/esm.mjs",
         "dist/bar/esm.d.mts",
         "dist/ts/test1.mjs",
         "dist/ts/test2.mjs",
         "dist/ts/test1.d.mts",
-        "dist/ts/test2.d.cts",
+        "dist/ts/test2.d.mts",
         "dist/nested.css",
         "dist/prop-types/index.mjs",
-        "dist/prop-types/index.d.ts",
+        "dist/prop-types/index.d.mts",
       ]
         .map((f) => resolve(rootDir, f))
         .sort(),
@@ -592,7 +594,7 @@ describe("mkdist with vue-tsc v1", () => {
       "manual declaration",
     );
 
-    expect(await readFile(resolve(rootDir, "dist/star/index.d.ts"), "utf8"))
+    expect(await readFile(resolve(rootDir, "dist/star/index.d.mts"), "utf8"))
       .toMatchInlineSnapshot(`
         "export * from "./other.js";
         export type { Other } from "./other.js";
@@ -604,7 +606,7 @@ describe("mkdist with vue-tsc v1", () => {
     ).toMatch("declare");
 
     expect(
-      await readFile(resolve(rootDir, "dist/components/index.d.ts"), "utf8"),
+      await readFile(resolve(rootDir, "dist/components/index.d.mts"), "utf8"),
     ).toMatchInlineSnapshot(`
       "export * as jsx from "./jsx.jsx.js";
       export * as tsx from "./tsx.tsx.js";
@@ -800,22 +802,23 @@ describe("mkdist with vue-tsc ~v2.0.21", () => {
     expect(writtenFiles.sort()).toEqual(
       [
         "dist/README.md",
-        "dist/bar.d.ts",
+        "dist/bar.d.mts",
         "dist/bar.mjs",
         "dist/demo.css",
-        "dist/dir-export.d.ts",
+        "dist/dir-export.d.mts",
         "dist/dir-export.mjs",
         "dist/foo.mjs",
+        "dist/foo.d.mts",
         "dist/foo.d.ts",
         "dist/index.mjs",
-        "dist/index.d.ts",
+        "dist/index.d.mts",
         "dist/star/index.mjs",
-        "dist/star/index.d.ts",
+        "dist/star/index.d.mts",
         "dist/star/other.mjs",
-        "dist/star/other.d.ts",
+        "dist/star/other.d.mts",
         "dist/types.d.ts",
         "dist/components/index.mjs",
-        "dist/components/index.d.ts",
+        "dist/components/index.d.mts",
         "dist/components/blank.vue",
         "dist/components/blank.vue.d.ts",
         "dist/components/js.vue",
@@ -828,19 +831,19 @@ describe("mkdist with vue-tsc ~v2.0.21", () => {
         "dist/components/ts.vue.d.ts",
         "dist/components/jsx.mjs",
         "dist/components/tsx.mjs",
-        "dist/components/jsx.d.ts",
-        "dist/components/tsx.d.ts",
+        "dist/components/jsx.d.mts",
+        "dist/components/tsx.d.mts",
         "dist/bar/index.mjs",
-        "dist/bar/index.d.ts",
+        "dist/bar/index.d.mts",
         "dist/bar/esm.mjs",
         "dist/bar/esm.d.mts",
         "dist/ts/test1.mjs",
         "dist/ts/test2.mjs",
         "dist/ts/test1.d.mts",
-        "dist/ts/test2.d.cts",
+        "dist/ts/test2.d.mts",
         "dist/nested.css",
         "dist/prop-types/index.mjs",
-        "dist/prop-types/index.d.ts",
+        "dist/prop-types/index.d.mts",
       ]
         .map((f) => resolve(rootDir, f))
         .sort(),
@@ -850,7 +853,7 @@ describe("mkdist with vue-tsc ~v2.0.21", () => {
       "manual declaration",
     );
 
-    expect(await readFile(resolve(rootDir, "dist/star/index.d.ts"), "utf8"))
+    expect(await readFile(resolve(rootDir, "dist/star/index.d.mts"), "utf8"))
       .toMatchInlineSnapshot(`
         "export * from "./other.js";
         export type { Other } from "./other.js";
@@ -862,7 +865,7 @@ describe("mkdist with vue-tsc ~v2.0.21", () => {
     ).toMatch("declare");
 
     expect(
-      await readFile(resolve(rootDir, "dist/components/index.d.ts"), "utf8"),
+      await readFile(resolve(rootDir, "dist/components/index.d.mts"), "utf8"),
     ).toMatchInlineSnapshot(`
       "export * as jsx from "./jsx.jsx.js";
       export * as tsx from "./tsx.tsx.js";


### PR DESCRIPTION
This is a partial fix for #138. (Wasn't sure if I should split it out into a new bug) It addresses the issue where changing the extension of the output does not affect extension of the declaration so there is a mismatch. It does not implement automatically choosing the extension based on the source file. 

> The other important thing is that .ts, .cts, .mts on the declaration files imply the existence of the file with the same basename: that is, index.d.ts says ‘the declaration file is for index.js’, a.d.cts is ‘for a.cjs’, and b.d.mts is ‘for b.mjs’. 

https://www.typescriptlang.org/docs/handbook/modules/reference.html#file-extension-substitution

The change itself is relatively straightforward, but it does have a large impact, especially because mjs is the default extension for esm output. Perhaps a major bump would be necessary or hiding the behavior behind a flag?

<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->
