### PR TITLE
feat: support dynamic imports with addRelativeDeclarationExtensions

### DIFF
--- a/src/utils/dts.ts
+++ b/src/utils/dts.ts
@@ -1,5 +1,10 @@
 import { statSync } from "node:fs";
-import { findStaticImports, findExports, findTypeExports } from "mlly";
+import {
+  findStaticImports,
+  findDynamicImports,
+  findExports,
+  findTypeExports,
+} from "mlly";
 import { resolve } from "pathe";
 import type { TSConfig } from "pkg-types";
 import type { MkdistOptions } from "../make";
@@ -64,7 +69,29 @@ export function extractDeclarations(
       const imports = findStaticImports(contents);
       const exports = findExports(contents);
       const typeExports = findTypeExports(contents);
-      for (const spec of [...exports, ...typeExports, ...imports]) {
+      const dynamicImports = findDynamicImports(contents).map(
+        (dynamicImport) => {
+          let specifier: string | undefined;
+          try {
+            const value = JSON.parse(dynamicImport.expression);
+            if (typeof value === "string") {
+              specifier = value;
+            }
+          } catch {
+            // ignore the error
+          }
+          return {
+            code: dynamicImport.code,
+            specifier,
+          };
+        },
+      );
+      for (const spec of [
+        ...exports,
+        ...typeExports,
+        ...imports,
+        ...dynamicImports,
+      ]) {
         if (!spec.specifier || !RELATIVE_RE.test(spec.specifier)) {
           continue;
         }

--- a/test/fixture/src/star/index.ts
+++ b/test/fixture/src/star/index.ts
@@ -1,2 +1,6 @@
 export * from "./other";
 export type { Other } from "./other";
+
+export function wonder(twinkle: import("./other").Other): string {
+  return twinkle;
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -160,6 +160,7 @@ describe("mkdist", () => {
       .toMatchInlineSnapshot(`
         "export * from "./other.js";
         export type { Other } from "./other.js";
+        export declare function wonder(twinkle: import("./other.js").Other): string;
         "
       `);
 
@@ -591,6 +592,7 @@ describe("mkdist with vue-tsc v1", () => {
       .toMatchInlineSnapshot(`
         "export * from "./other.js";
         export type { Other } from "./other.js";
+        export declare function wonder(twinkle: import("./other.js").Other): string;
         "
       `);
     expect(
@@ -848,6 +850,7 @@ describe("mkdist with vue-tsc ~v2.0.21", () => {
       .toMatchInlineSnapshot(`
         "export * from "./other.js";
         export type { Other } from "./other.js";
+        export declare function wonder(twinkle: import("./other.js").Other): string;
         "
       `);
     expect(


### PR DESCRIPTION
#267 

This patch extends the `addRelativeDeclarationExtensions` functionality to also add the extension when `import()` is used. 

**Before:**

```ts
export * from "./other.js";
export type { Other } from "./other.js";
export declare function wonder(twinkle: import("./other").Other): string;
```

**After:**

```ts
export * from "./other.js";
export type { Other } from "./other.js";
export declare function wonder(twinkle: import("./other.js").Other): string;
```


<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->
