### PR TITLE
feat: add support for generating sourcemaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,11 @@ While there are tools like [tsc](https://www.typescriptlang.org/docs/handbook/co
 ## 🚀 Usage
 
 ```bash
-npx mkdist [rootDir] [--src=src] [--dist=dist] [--no-clean] [--pattern=glob [--pattern=more-glob]] [--format=cjs|esm] [-d|--declaration] [--ext=mjs|js|ts]
+npx mkdist [rootDir] [--src=src] [--dist=dist] [--no-clean] [--pattern=glob [--pattern=more-glob]] [--format=cjs|esm] [-d|--declaration] [--ext=mjs|js|ts] [--sourcemap[=linked|inline|external|both]]
 ```
+
+Source maps are generated for JavaScript inputs. The Vue loader does not emit
+source maps.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test": "pnpm lint && vitest run --coverage"
   },
   "dependencies": {
+    "@jridgewell/sourcemap-codec": "1.5.5",
     "autoprefixer": "^10.4.21",
     "citty": "^0.1.6",
     "cssnano": "^8.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@jridgewell/sourcemap-codec':
+        specifier: 1.5.5
+        version: 1.5.5
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.21(postcss@8.5.6)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -85,8 +85,19 @@ const main = defineCommand({
       type: "string",
       description: "Target environment (esbuild)",
     },
+    sourcemap: {
+      type: "string",
+      description: "Emit sourcemap (esbuild)",
+      valueHint: "linked|inline|external|both",
+    },
   },
   async run({ args }) {
+    if (
+      args.sourcemap !== undefined &&
+      !["linked", "inline", "external", "both"].includes(args.sourcemap)
+    ) {
+      throw new TypeError(`Invalid sourcemap mode: ${args.sourcemap}`);
+    }
     const { writtenFiles } = await mkdist({
       rootDir: resolve(args.cwd || process.cwd(), args.dir),
       srcDir: args.src,
@@ -103,6 +114,7 @@ const main = defineCommand({
         jsxFragment: args.jsxFragment,
         minify: args.minify,
         target: args.target,
+        sourcemap: args.sourcemap,
       },
     } as MkdistOptions);
 
@@ -112,8 +124,36 @@ const main = defineCommand({
   },
 });
 
-// eslint-disable-next-line unicorn/prefer-top-level-await
-runMain(main).catch((error) => {
-  console.error(error);
-  process.exit(1);
-});
+const valueOptions = new Set([
+  "--cwd",
+  "--src",
+  "--dist",
+  "--pattern",
+  "--format",
+  "--ext",
+  "--jsx",
+  "--jsxFactory",
+  "--jsx-factory",
+  "--jsxFragment",
+  "--jsx-fragment",
+  "--loaders",
+  "--target",
+]);
+const rawArgs = process.argv.slice(2);
+const separatorIndex = rawArgs.indexOf("--");
+const optionsEnd = separatorIndex === -1 ? rawArgs.length : separatorIndex;
+for (let index = 0; index < optionsEnd; index++) {
+  if (
+    rawArgs[index] === "--sourcemap" &&
+    (index === 0 || !valueOptions.has(rawArgs[index - 1]))
+  ) {
+    rawArgs[index] = "--sourcemap=linked";
+  }
+}
+
+runMain(main, { rawArgs })
+  // eslint-disable-next-line unicorn/prefer-top-level-await
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -23,6 +23,7 @@ export interface OutputFile {
   srcPath?: string;
   extension?: string;
   contents?: string;
+  sourceMap?: string;
   declaration?: boolean;
   errors?: Error[];
   raw?: boolean;

--- a/src/loaders/index.ts
+++ b/src/loaders/index.ts
@@ -4,17 +4,18 @@ import { vueLoader } from "./vue";
 import { sassLoader } from "./sass";
 import { postcssLoader } from "./postcss";
 
-let cachedVueLoader: Loader | undefined;
-
 export const loaders = {
   js: jsLoader,
-  vue:
-    cachedVueLoader ||
-    (async (...args) => {
-      cachedVueLoader = await import("vue-sfc-transformer/mkdist")
-        .then((r) => r.vueLoader)
-        .catch(() => vueLoader);
-      return cachedVueLoader(...args);
+  vue: async (input, context) =>
+    vueLoader(input, {
+      ...context,
+      options: {
+        ...context.options,
+        esbuild: context.options.esbuild && {
+          ...context.options.esbuild,
+          sourcemap: false,
+        },
+      },
     }),
   sass: sassLoader,
   postcss: postcssLoader,

--- a/src/loaders/js.ts
+++ b/src/loaders/js.ts
@@ -7,6 +7,8 @@ const DECLARATION_RE = /\.d\.[cm]?ts$/;
 const CM_LETTER_RE = /(?<=\.)(c|m)(?=[jt]s$)/;
 
 const KNOWN_EXT_RE = /\.(c|m)?[jt]sx?$/;
+const INLINE_SOURCE_MAP_RE =
+  /\n?\/\/# sourceMappingURL=data:application\/json(?:;charset=utf-8)?;base64,([^\n]+)\n?$/;
 
 const TS_EXTS = new Set([".ts", ".mts", ".cts"]);
 
@@ -18,6 +20,7 @@ export const jsLoader: Loader = async (input, { options }) => {
   const output: LoaderResult = [];
 
   let contents = await input.getContents();
+  let sourceMapping = "";
 
   // declaration
   if (options.declaration && !input.srcPath?.match(DECLARATION_RE)) {
@@ -33,26 +36,97 @@ export const jsLoader: Loader = async (input, { options }) => {
   }
 
   // typescript => js
+  const isCjs = options.format === "cjs";
+  const sourceMap = options.esbuild?.sourcemap;
+  const sourceMapEnabled =
+    sourceMap === true ||
+    sourceMap === "linked" ||
+    sourceMap === "inline" ||
+    sourceMap === "external" ||
+    sourceMap === "both";
+  const sourcemap = sourceMapEnabled ? "external" : sourceMap;
+  let loader: "ts" | "tsx" | "jsx" | "js" | undefined;
   if (TS_EXTS.has(input.extension)) {
-    contents = await transform(contents, {
+    loader = "ts";
+  } else if (input.extension === ".tsx") {
+    loader = "tsx";
+  } else if (input.extension === ".jsx") {
+    loader = "jsx";
+  } else if (sourcemap) {
+    loader = "js";
+  }
+  if (loader) {
+    const result = await transform(contents, {
       ...options.esbuild,
-      loader: "ts",
-    }).then((r) => r.code);
-  } else if ([".tsx", ".jsx"].includes(input.extension)) {
-    contents = await transform(contents, {
-      loader: input.extension === ".tsx" ? "tsx" : "jsx",
-      ...options.esbuild,
-    }).then((r) => r.code);
+      sourcemap,
+      sourcefile: input.srcPath,
+      loader,
+    });
+    contents = result.code;
+    sourceMapping = result.map;
   }
 
   // esm => cjs
-  const isCjs = options.format === "cjs";
   if (isCjs) {
-    contents = jiti("")
-      .transform({ source: contents, retainLines: false })
-      .replace(/^exports.default = /gm, "module.exports = ")
-      .replace(/^var _default = exports.default = /gm, "module.exports = ")
-      .replace("module.exports = void 0;", "");
+    const inputSourceMap = sourceMapEnabled
+      ? JSON.parse(sourceMapping)
+      : undefined;
+    const sourceRoot = inputSourceMap?.sourceRoot;
+    // Babel resolves sourceRoot into each source during map composition.
+    if (inputSourceMap) {
+      delete inputSourceMap.sourceRoot;
+    }
+    const stackTraceLimit = Error.stackTraceLimit;
+    try {
+      // Prevent caller source-map hooks from breaking Jiti's synchronous transform.
+      if (sourceMapEnabled) {
+        Error.stackTraceLimit = 0;
+      }
+      contents = jiti(
+        "",
+        sourceMapEnabled
+          ? {
+              cache: false,
+              sourceMaps: true,
+              transformOptions: {
+                babel: { inputSourceMap },
+              },
+            }
+          : undefined,
+      ).transform({
+        source: contents,
+        retainLines: false,
+        ...(sourceMapEnabled && { filename: input.path }),
+      });
+    } finally {
+      Error.stackTraceLimit = stackTraceLimit;
+    }
+
+    if (sourceMapEnabled) {
+      const match = contents.match(INLINE_SOURCE_MAP_RE);
+      if (!match || match.index === undefined) {
+        throw new Error(
+          `[mkdist] Failed to generate source map for ${input.path}`,
+        );
+      }
+      sourceMapping = Buffer.from(match[1], "base64").toString("utf8");
+      if (sourceRoot !== undefined) {
+        const parsed = JSON.parse(sourceMapping);
+        parsed.sourceRoot = sourceRoot;
+        sourceMapping = JSON.stringify(parsed);
+      }
+      contents = contents.slice(0, match.index);
+    }
+    const replaceWith = (replacement: string) => (value: string) =>
+      sourceMapEnabled ? replacement.padEnd(value.length) : replacement;
+    contents = contents
+      .replace("exports.default = void 0;", replaceWith(""))
+      .replace("module.exports = void 0;", replaceWith(""))
+      .replace(/^exports.default = /gm, replaceWith("module.exports = "))
+      .replace(
+        /^var _default = exports.default = /gm,
+        replaceWith("module.exports = "),
+      );
   }
 
   let extension = isCjs ? ".js" : ".mjs"; // TODO: Default to .cjs in next major version
@@ -62,6 +136,7 @@ export const jsLoader: Loader = async (input, { options }) => {
 
   output.push({
     contents,
+    sourceMap: sourceMapping || undefined,
     path: input.path,
     extension,
   });

--- a/src/make.ts
+++ b/src/make.ts
@@ -1,4 +1,12 @@
-import { resolve, extname, join, basename, dirname } from "pathe";
+import {
+  resolve,
+  extname,
+  join,
+  basename,
+  dirname,
+  relative,
+  isAbsolute,
+} from "pathe";
 import fsp from "node:fs/promises";
 import type { TSConfig } from "pkg-types";
 import defu from "defu";
@@ -18,6 +26,65 @@ import {
 import { getVueDeclarations } from "./utils/vue-dts";
 import { LoaderName } from "./loaders";
 import { glob, type GlobOptions } from "tinyglobby";
+import { decode, encode } from "@jridgewell/sourcemap-codec";
+import { findDynamicImports, findExports, findStaticImports } from "mlly";
+
+interface SourceMapEdit {
+  end: number;
+  delta: number;
+}
+
+const IMPORT_TRIVIA_RE = /^(?:\s|\/\*[\s\S]*?\*\/|\/\/[^\n]*(?:\n|$))*/;
+
+function findImportIds(contents: string) {
+  return findDynamicImports(contents).flatMap(({ code, expression, start }) => {
+    const leadingTrivia = expression.match(IMPORT_TRIVIA_RE)?.[0] || "";
+    const literal = expression
+      .slice(leadingTrivia.length)
+      .match(/^(["'])((?:\\.|[^\\])*?)\1/);
+    if (!literal) {
+      return [];
+    }
+    const rest = expression.slice(leadingTrivia.length + literal[0].length);
+    const trailingTrivia = rest.match(IMPORT_TRIVIA_RE)?.[0] || "";
+    const remainder = rest.slice(trailingTrivia.length);
+    if (remainder && !remainder.startsWith(",")) {
+      return [];
+    }
+    return [
+      {
+        id: literal[2],
+        index: start + code.indexOf(expression) + leadingTrivia.length + 1,
+      },
+    ];
+  });
+}
+
+function shiftSourceMap(
+  sourceMap: string | undefined,
+  contents: string,
+  edits: SourceMapEdit[],
+) {
+  if (!sourceMap || edits.length === 0) {
+    return sourceMap;
+  }
+
+  const parsed = JSON.parse(sourceMap) as { mappings: string };
+  const mappings = decode(parsed.mappings);
+  // Apply edits right-to-left so each threshold stays in original coordinates.
+  for (const edit of edits.sort((a, b) => b.end - a.end)) {
+    const before = contents.slice(0, edit.end);
+    const line = before.split("\n").length - 1;
+    const column = edit.end - before.lastIndexOf("\n") - 1;
+    for (const segment of mappings[line] || []) {
+      if (segment[0] >= column) {
+        segment[0] += edit.delta;
+      }
+    }
+  }
+  parsed.mappings = encode(mappings);
+  return JSON.stringify(parsed);
+}
 
 export interface MkdistOptions extends LoaderOptions {
   rootDir?: string;
@@ -145,6 +212,28 @@ export async function mkdist(
     }
     return id;
   };
+  const rewriteIds = (
+    output: OutputFile,
+    ids: Array<{ id: string; index: number }>,
+    resolveExtensions: string[],
+  ) => {
+    const contents = output.contents;
+    const edits: SourceMapEdit[] = [];
+    for (const { id, index } of ids.sort((a, b) => b.index - a.index)) {
+      const resolved = resolveId(output.path, id, resolveExtensions);
+      if (resolved !== id) {
+        edits.push({
+          end: index + id.length,
+          delta: resolved.length - id.length,
+        });
+        output.contents =
+          output.contents.slice(0, index) +
+          resolved +
+          output.contents.slice(index + id.length);
+      }
+    }
+    output.sourceMap = shiftSourceMap(output.sourceMap, contents, edits);
+  };
   const esmResolveExtensions = [
     "",
     "/index.mjs",
@@ -156,36 +245,63 @@ export async function mkdist(
   for (const output of outputs.filter(
     (o) => o.extension === ".mjs" || o.extension === ".js",
   )) {
-    // Resolve import statements
-    output.contents = output.contents
-      .replace(
-        /(import|export)(\s+(?:.+|{[\s\w,]+})\s+from\s+["'])(.*)(["'])/g,
-        (_, type, head, id, tail) =>
-          type + head + resolveId(output.path, id, esmResolveExtensions) + tail,
-      )
-      // Resolve dynamic import
-      .replace(
-        /import\((["'])(.*)(["'])\)/g,
-        (_, head, id, tail) =>
-          "import(" +
-          head +
-          resolveId(output.path, id, esmResolveExtensions) +
-          tail +
-          ")",
-      );
+    const ids = [
+      ...findStaticImports(output.contents),
+      ...findExports(output.contents),
+    ].flatMap(({ code, start, specifier }) =>
+      specifier
+        ? [{ id: specifier, index: start + code.lastIndexOf(specifier) }]
+        : [],
+    );
+    ids.push(...findImportIds(output.contents));
+    rewriteIds(output, ids, esmResolveExtensions);
   }
   const cjsResolveExtensions = ["", "/index.cjs", ".cjs"];
   for (const output of outputs.filter((o) => o.extension === ".cjs")) {
-    // Resolve require statements
-    output.contents = output.contents.replace(
-      /require\((["'])(.*)(["'])\)/g,
-      (_, head, id, tail) =>
-        "require(" +
-        head +
-        resolveId(output.path, id, cjsResolveExtensions) +
-        tail +
-        ")",
+    // Reuse mlly's token filtering while preserving the original offsets.
+    const importCode = output.contents.replace(
+      /(^|[^\w$.])require\b/g,
+      "$1import ",
     );
+    rewriteIds(output, findImportIds(importCode), cjsResolveExtensions);
+  }
+
+  // Emit source maps after all output rewrites.
+  const sourcemap = options.esbuild?.sourcemap;
+  for (const output of sourcemap
+    ? outputs.filter((o) => o.sourceMap && !o.skip)
+    : []) {
+    const sourceMap = JSON.parse(output.sourceMap) as { sources: string[] };
+    const sourceMapDir = dirname(join(options.distDir, `${output.path}.map`));
+    sourceMap.sources = sourceMap.sources.map((source) =>
+      isAbsolute(source) ? relative(sourceMapDir, source) : source,
+    );
+    output.sourceMap = JSON.stringify(sourceMap);
+
+    if (sourcemap !== "inline") {
+      const path = `${output.path}.map`;
+      const existing = outputs.find(
+        (output) => !output.skip && output.path === path,
+      );
+      if (existing) {
+        existing.contents = output.sourceMap;
+        existing.raw = false;
+      } else {
+        outputs.push({ path, contents: output.sourceMap });
+      }
+    }
+    if (sourcemap === "inline" || sourcemap === "both") {
+      const encoded = Buffer.from(output.sourceMap).toString("base64");
+      output.contents += `\n//# sourceMappingURL=data:application/json;base64,${encoded}`;
+    } else if (sourcemap === true || sourcemap === "linked") {
+      const sourceMapUrl = encodeURIComponent(
+        `${basename(output.path)}.map`,
+      ).replace(
+        /[!'()*]/g,
+        (character) => `%${character.charCodeAt(0).toString(16).toUpperCase()}`,
+      );
+      output.contents += `\n//# sourceMappingURL=${sourceMapUrl}`;
+    }
   }
 
   // Write outputs

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,4 +1,6 @@
 import { readFile } from "node:fs/promises";
+import { SourceMap } from "node:module";
+import { spawnSync } from "node:child_process";
 import { relative, resolve } from "pathe";
 import {
   describe,
@@ -12,6 +14,9 @@ import {
 import { createLoader } from "../src/loader";
 
 describe("mkdist", () => {
+  const mapRoot = resolve(__dirname, "sourcemap-fixture");
+  const readSourceMap = async (path: string) =>
+    new SourceMap(JSON.parse(await readFile(resolve(mapRoot, path), "utf8")));
   let mkdist: typeof import("../src/make").mkdist;
 
   beforeAll(async () => {
@@ -256,6 +261,296 @@ describe("mkdist", () => {
       "
     `);
   }, 50_000);
+
+  it("mkdist (emit sourcemaps)", async () => {
+    const rootDir = resolve(__dirname, "fixture");
+    const { writtenFiles } = await mkdist({
+      rootDir,
+      esbuild: {
+        sourcemap: "linked",
+      },
+    });
+
+    expect(writtenFiles.filter((file) => file.endsWith(".map")).sort()).toEqual(
+      [
+        "dist/bar.mjs.map",
+        "dist/dir-export.mjs.map",
+        "dist/foo.mjs.map",
+        "dist/index.mjs.map",
+        "dist/star/index.mjs.map",
+        "dist/star/other.mjs.map",
+        "dist/components/index.mjs.map",
+        "dist/components/jsx.mjs.map",
+        "dist/components/tsx.mjs.map",
+        "dist/bar/index.mjs.map",
+        "dist/bar/esm.mjs.map",
+        "dist/ts/test1.mjs.map",
+        "dist/ts/test2.mjs.map",
+        "dist/prop-types/index.mjs.map",
+      ]
+        .map((f) => resolve(rootDir, f))
+        .sort(),
+    );
+
+    expect(await readFile(resolve(rootDir, "dist/index.mjs"), "utf8")).toMatch(
+      /\n\/\/# sourceMappingURL=index.mjs.map$/,
+    );
+
+    expect(
+      JSON.parse(await readFile(resolve(rootDir, "dist/bar.mjs.map"), "utf8"))
+        .sourcesContent[0],
+    ).toMatch(await readFile(resolve(rootDir, "src/bar.ts"), "utf8"));
+  });
+
+  it.each([
+    ["disabled", false, false, false],
+    ["inline", "inline", true, false],
+    ["external", "external", false, true],
+    ["both", "both", true, true],
+  ] as const)(
+    "mkdist (%s sourcemaps)",
+    async (_, sourcemap, hasInlineMap, hasExternalMap) => {
+      const { writtenFiles } = await mkdist({
+        rootDir: mapRoot,
+        pattern: "input.js",
+        esbuild: { sourcemap },
+      });
+      const output = await readFile(resolve(mapRoot, "dist/input.mjs"), "utf8");
+
+      expect(
+        output.includes("sourceMappingURL=data:application/json;base64,"),
+      ).toBe(hasInlineMap);
+      expect(writtenFiles.some((file) => file.endsWith(".map"))).toBe(
+        hasExternalMap,
+      );
+    },
+  );
+
+  it("source CLI handles sourcemap modes", async () => {
+    const command = [
+      resolve(__dirname, "../node_modules/jiti/bin/jiti.js"),
+      resolve(__dirname, "../src/cli.ts"),
+      mapRoot,
+      "--pattern=input.js",
+    ];
+    const bare = spawnSync(process.execPath, [...command, "--sourcemap"], {
+      encoding: "utf8",
+    });
+
+    expect(bare.status).toBe(0);
+    expect(bare.stdout).toContain("input.mjs.map");
+    expect(await readFile(resolve(mapRoot, "dist/input.mjs"), "utf8")).toMatch(
+      /\n\/\/# sourceMappingURL=input.mjs.map$/,
+    );
+
+    const optionValue = spawnSync(
+      process.execPath,
+      [...command, "--ext", "--sourcemap"],
+      { encoding: "utf8" },
+    );
+    expect(optionValue.status).toBe(1);
+    expect(optionValue.stderr).toContain("Invalid sourcemap mode:");
+
+    const invalid = spawnSync(
+      process.execPath,
+      [...command, "--sourcemap=invalid"],
+      { encoding: "utf8" },
+    );
+    expect(invalid.status).toBe(1);
+    expect(invalid.stderr).toContain("Invalid sourcemap mode: invalid");
+
+    const empty = spawnSync(process.execPath, [...command, "--sourcemap="], {
+      encoding: "utf8",
+    });
+    expect(empty.status).toBe(1);
+    expect(empty.stderr).toContain("Invalid sourcemap mode:");
+  });
+
+  it("mkdist (emits sourcemaps for native JavaScript extensions)", async () => {
+    const { writtenFiles } = await mkdist({
+      rootDir: mapRoot,
+      pattern: ["native-cjs.cjs", "native-esm.mjs"],
+      esbuild: { sourcemap: "external" },
+    });
+
+    expect(writtenFiles.map((file) => relative(mapRoot, file)).sort()).toEqual([
+      "dist/native-cjs.mjs",
+      "dist/native-cjs.mjs.map",
+      "dist/native-esm.mjs",
+      "dist/native-esm.mjs.map",
+    ]);
+  });
+
+  it("mkdist (keep sourcemaps aligned with true)", async () => {
+    const { writtenFiles } = await mkdist({
+      rootDir: mapRoot,
+      pattern: "input.js",
+      esbuild: {
+        sourcemap: true,
+      },
+    });
+
+    const output = await readFile(resolve(mapRoot, "dist/input.mjs"), "utf8");
+    const sourceMap = await readSourceMap("dist/input.mjs.map");
+    const generatedColumn = output.indexOf("module.answer");
+    const mapping = sourceMap.findEntry(0, generatedColumn);
+
+    expect(writtenFiles.sort()).toEqual(
+      ["dist/input.mjs", "dist/input.mjs.map"]
+        .map((file) => resolve(mapRoot, file))
+        .sort(),
+    );
+    expect(output).toMatch(/\n\/\/# sourceMappingURL=input.mjs.map$/);
+    expect(sourceMap.payload.sources).toEqual(["../src/input.js"]);
+    expect(mapping).toMatchObject({
+      generatedColumn,
+      originalLine: 0,
+      originalColumn: 61,
+    });
+  });
+
+  it("mkdist (keeps sourcemaps aligned after static import rewrites)", async () => {
+    await mkdist({
+      rootDir: mapRoot,
+      pattern: ["input.js", "native-esm.mjs", "static.js"],
+      esbuild: {
+        sourcemap: true,
+        minifyWhitespace: true,
+      },
+    });
+
+    const output = await readFile(resolve(mapRoot, "dist/static.mjs"), "utf8");
+    const sourceMap = await readSourceMap("dist/static.mjs.map");
+    const generatedColumn = output.indexOf("value=answer+Number(native)");
+
+    expect(output).toContain('from"./input.mjs"');
+    expect(output).toContain('from"./native-esm.mjs"');
+    expect(output).toContain('from "./input"');
+    expect(output).not.toContain('from "./input.mjs"');
+    expect(output).toContain('import("./input.mjs",{with:{type:"json"}})');
+    expect(output).toContain('import("./input"+part)');
+    expect(sourceMap.findEntry(0, generatedColumn)).toMatchObject({
+      generatedColumn,
+      originalLine: 2,
+      originalColumn: 13,
+    });
+
+    await mkdist({ rootDir: mapRoot, pattern: ["input.js", "static.js"] });
+    const commentedOutput = await readFile(
+      resolve(mapRoot, "dist/static.mjs"),
+      "utf8",
+    );
+    expect(commentedOutput).toContain(
+      'import(/* chunk */ "./input.mjs" /* @vite-ignore */, {',
+    );
+  });
+
+  it("mkdist (keep sourcemaps aligned after CJS conversion)", async () => {
+    await mkdist({
+      rootDir: mapRoot,
+      pattern: "input.js",
+      format: "cjs",
+      ext: "cjs",
+      esbuild: {
+        sourcemap: "linked",
+        sourceRoot: "https://host/root/",
+      },
+    });
+
+    const output = await readFile(resolve(mapRoot, "dist/input.cjs"), "utf8");
+    const sourceMap = await readSourceMap("dist/input.cjs.map");
+    const generatedIndex = output.indexOf("module.answer");
+    const generatedLine =
+      output.slice(0, generatedIndex).split("\n").length - 1;
+    const generatedColumn =
+      generatedIndex - output.lastIndexOf("\n", generatedIndex) - 1;
+    const mapping = sourceMap.findEntry(generatedLine, generatedColumn);
+
+    expect(output).toContain('require("./input.cjs")');
+    expect(output).toContain('require("./input")');
+    expect(output).not.toContain("module.exports =  void 0;");
+    expect(sourceMap.payload).toMatchObject({
+      sourceRoot: "https://host/root/",
+      sources: ["../src/input.js"],
+    });
+    expect(mapping).toMatchObject({
+      generatedLine,
+      generatedColumn,
+      originalLine: 0,
+      originalColumn: 61,
+    });
+
+    const fixtureRootDir = resolve(__dirname, "fixture");
+    await mkdist({
+      rootDir: fixtureRootDir,
+      pattern: "bar.ts",
+      format: "cjs",
+      ext: "cjs",
+    });
+
+    const plainOutput = await readFile(
+      resolve(fixtureRootDir, "dist/bar.cjs"),
+      "utf8",
+    );
+    expect(plainOutput).not.toContain("module.exports = void 0;");
+  });
+
+  it("mkdist (ignores loader sourcemaps when disabled)", async () => {
+    const { writtenFiles } = await mkdist({
+      rootDir: mapRoot,
+      pattern: "input.js",
+      loaders: [
+        () => [
+          {
+            path: "input.js",
+            extension: ".mjs",
+            contents: "",
+            sourceMap: '{"version":3,"sources":[],"names":[],"mappings":""}',
+          },
+        ],
+      ],
+    });
+
+    expect(writtenFiles).toEqual([resolve(mapRoot, "dist/input.mjs")]);
+  });
+
+  it("mkdist (emits a valid linked source map on collision)", async () => {
+    const generatedSourceMap =
+      '{"version":3,"sources":[],"names":[],"mappings":""}';
+    const { writtenFiles } = await mkdist({
+      rootDir: mapRoot,
+      pattern: "input.js",
+      loaders: [
+        () => [
+          {
+            path: "input !'().js",
+            extension: ".mjs",
+            contents: "",
+            sourceMap: generatedSourceMap,
+          },
+          {
+            path: "input !'().mjs.map",
+            contents: "existing",
+          },
+        ],
+      ],
+      esbuild: {
+        sourcemap: "linked",
+      },
+    });
+
+    expect(writtenFiles.sort()).toEqual(
+      ["dist/input !'().mjs", "dist/input !'().mjs.map"]
+        .map((file) => resolve(mapRoot, file))
+        .sort(),
+    );
+    expect(
+      await readFile(resolve(mapRoot, "dist/input !'().mjs.map"), "utf8"),
+    ).toBe(generatedSourceMap);
+    expect(
+      await readFile(resolve(mapRoot, "dist/input !'().mjs"), "utf8"),
+    ).toMatch(/\n\/\/# sourceMappingURL=input%20%21%27%28%29.mjs.map$/);
+  });
 
   describe("mkdist (sass compilation)", () => {
     const rootDir = resolve(__dirname, "fixture");
@@ -626,12 +921,14 @@ describe("mkdist", () => {
 });
 
 describe("mkdist with fallback vue loader", () => {
+  let createFallbackLoader: typeof createLoader;
   const consoleWarnSpy = vi.spyOn(console, "warn");
   beforeAll(async () => {
     vi.resetModules();
     vi.doMock("vue-sfc-transformer/mkdist", async () => {
       throw new Error("vue-sfc-transformer is not installed");
     });
+    createFallbackLoader = (await import("../src/loader")).createLoader;
   });
 
   afterAll(() => {
@@ -707,7 +1004,7 @@ describe("mkdist with fallback vue loader", () => {
   });
 
   async function fixture(input: string) {
-    const { loadFile } = createLoader({
+    const { loadFile } = createFallbackLoader({
       loaders: ["vue", "js", "sass"],
     });
     const results = await loadFile({
@@ -724,12 +1021,11 @@ describe("mkdist with fallback vue loader (emit types)", () => {
 
   const consoleWarnSpy = vi.spyOn(console, "warn");
   beforeAll(async () => {
-    mkdist = (await import("../src/make")).mkdist;
-
     vi.resetModules();
     vi.doMock("vue-sfc-transformer/mkdist", async () => {
       throw new Error("vue-sfc-transformer is not installed");
     });
+    mkdist = (await import("../src/make")).mkdist;
   });
 
   afterAll(() => {
@@ -894,10 +1190,13 @@ describe("mkdist with fallback vue loader (emit types)", () => {
       "
     `);
 
-    expect(consoleWarnSpy).toHaveBeenCalledWith(
-      "[mkdist] vue-sfc-transformer is not installed. mkdist will not transform typescript syntax in Vue SFCs.",
-    );
-    expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+    expect(
+      consoleWarnSpy.mock.calls.filter(
+        ([message]) =>
+          message ===
+          "[mkdist] vue-sfc-transformer is not installed. mkdist will not transform typescript syntax in Vue SFCs.",
+      ),
+    ).toHaveLength(1);
   }, 50_000);
 });
 

--- a/test/sourcemap-fixture/src/input.js
+++ b/test/sourcemap-fixture/src/input.js
@@ -1,0 +1,4 @@
+export const load = () => import("./input").then((module) => module.answer);
+export const answer = 42;
+export default answer;
+export const requireText = 'require("./input")';

--- a/test/sourcemap-fixture/src/native-cjs.cjs
+++ b/test/sourcemap-fixture/src/native-cjs.cjs
@@ -1,0 +1,1 @@
+module.exports = true;

--- a/test/sourcemap-fixture/src/native-esm.mjs
+++ b/test/sourcemap-fixture/src/native-esm.mjs
@@ -1,0 +1,1 @@
+export const native = true;

--- a/test/sourcemap-fixture/src/static.js
+++ b/test/sourcemap-fixture/src/static.js
@@ -1,0 +1,9 @@
+import { answer } from "./input";
+import { native } from "./native-esm";
+export const value = answer + Number(native);
+export const important = 'from "./input"';
+export const loadWithOptions = () =>
+  import(/* chunk */ "./input" /* @vite-ignore */, {
+    with: { type: "json" },
+  });
+export const loadPart = (part) => import("./input" + part);


### PR DESCRIPTION
Resolves #164

The CLI now accepts a `--sourcemap` option that should match the behaviour of `esbuild`'s `--sourcemap` option. The programmatic API's `esbuild.sourcemap` option should now also match with `esbuild`'s `sourcemap` option for the Build API.

The `sourcemap: 'linked'` option is special cased in the implementation, since `esbuild` doesn't support the option under the Transform API that `mkdist` uses [^1].

Refs: https://esbuild.github.io/api/#sourcemap
Refs: https://sourcemaps.info/spec.html

[^1]: https://github.com/evanw/esbuild/blob/745abd9f0c06f73ca40fbe198546a9bc36c23b81/pkg/api/api_impl.go#L1749

<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable sourcemap generation to the command-line build workflow.
  * Supports linked, inline, external, and combined sourcemap modes, with bare `--sourcemap` defaulting to linked.
  * Preserves accurate mappings through imports, exports, dynamic imports, CommonJS conversion, and supported native modules.
  * Linked maps are emitted separately and referenced from generated output.
  * Invalid sourcemap options now produce clear CLI errors.

* **Documentation**
  * Documented sourcemap options and JavaScript/Vue loader support.

* **Tests**
  * Added comprehensive coverage for sourcemap modes, mappings, metadata, collisions, and CLI validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->