### PR TITLE
feat(dts): expose ts compiler errors

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -24,6 +24,7 @@ export interface OutputFile {
   extension?: string;
   contents?: string;
   declaration?: boolean;
+  errors?: Error[];
   raw?: boolean;
   skip?: boolean;
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,5 @@
 import { readFile } from "node:fs/promises";
-import { resolve } from "pathe";
+import { relative, resolve } from "pathe";
 import {
   describe,
   it,
@@ -497,6 +497,28 @@ describe("mkdist", () => {
       "
     `);
   });
+
+  it("emits DTS errors", async () => {
+    const rootDir = resolve(__dirname, "fixture");
+    const { mkdist } = await import("../src/make");
+    const { errors } = await mkdist({
+      rootDir,
+      declaration: true,
+      typescript: {
+        compilerOptions: {
+          // force compiler errors to be emitted
+          noEmitOnError: true,
+        },
+      },
+    });
+    const files = errors.map((e) => relative(rootDir, e.filename));
+    expect(files).toMatchInlineSnapshot(`
+      [
+        "dist/components/index.d.ts",
+        "dist/components/tsx.d.ts",
+      ]
+    `);
+  }, 50_000);
 });
 
 describe("mkdist with vue-tsc v1", () => {


### PR DESCRIPTION
It's possible for compiler errors to occur when processing individual declarations - this causes empty files which will (silently) break builds.

This exposes an `errors` object which can be handled by builders like `unbuild` to throw an error and fail the build in this case, if so configured. (It does not change default behaviour.)

While debugging, I removed the incorrect `incremental` compiler option and added the more permissive `allowImportingTsExtensions`.