### PR TITLE
fix: only add known ignore patterns by default

### DIFF
--- a/src/make.ts
+++ b/src/make.ts
@@ -49,21 +49,9 @@ export async function mkdist(
   }
 
   // Scan input files
-  const ignored = await fsp
-    .readFile(resolve(options.rootDir, ".gitignore"), "utf8")
-    .then((r) =>
-      r
-        .split("\n")
-        .map((r) => r.trim())
-        .filter((r) => r && !r.startsWith("#"))
-        // Gitignore => Glob
-        // TODO: https://github.com/unjs/mkdist/issues/271
-        .map((r) => (r.startsWith("/") ? r.slice(1) : r)),
-    )
-    .catch(() => []);
   const filePaths = await glob(options.pattern || "**", {
     absolute: false,
-    ignore: ignored,
+    ignore: ["**/node_modules", "**/coverage", "**/.git"],
     cwd: options.srcDir,
     dot: true,
     ...options.globOptions,


### PR DESCRIPTION
Relavant issues: #265, https://github.com/unjs/unbuild/issues/472

This PR replaces problematic gitignore inferences with only known patterns `["**/node_modules", "**/coverage", "**/.git"]` (same as `globby` defaults)

Context: #253 enabled dotfiles scanning and at the same time we added a small solution to infer gitignore patterns. however, it is problematic because `tinyglobby` unlike `globby` does not natively has gitignore support and gitignore patterns are not same as glob patterns (#265)

This PR is an alternative to #271 because even if using [ignore](https://www.npmjs.com/package/ignore) util, we need to convert scanned paths to be relative from root before matching (which is likely to have more edge cases), we need nested gitignore support and on top of all this, it still breaks situation when it is intended to build an autogenerated and ignored file from `src`.

