### PR TITLE
chore: replace `latest` ranges with caret ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@volar/typescript": "2.4.23",
     "@vue/language-core": "3.0.6",
     "@vue/language-core2.0": "npm:@vue/language-core@2.0.29",
-    "c8": "latest",
+    "c8": "^11.0.0",
     "changelogen": "0.6.2",
     "eslint": "10.0.2",
     "eslint-config-unjs": "0.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,7 +67,7 @@ importers:
         specifier: npm:@vue/language-core@2.0.29
         version: '@vue/language-core@2.0.29(typescript@5.9.2)'
       c8:
-        specifier: latest
+        specifier: ^11.0.0
         version: 11.0.0
       changelogen:
         specifier: 0.6.2
@@ -1472,10 +1472,6 @@ packages:
   istanbul-lib-source-maps@5.0.6:
     resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
     engines: {node: '>=10'}
-
-  istanbul-reports@3.1.7:
-    resolution: {integrity: sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==}
-    engines: {node: '>=8'}
 
   istanbul-reports@3.2.0:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
@@ -3348,7 +3344,7 @@ snapshots:
       foreground-child: 3.3.1
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
-      istanbul-reports: 3.1.7
+      istanbul-reports: 3.2.0
       test-exclude: 8.0.0
       v8-to-istanbul: 9.3.0
       yargs: 17.7.2
@@ -3935,11 +3931,6 @@ snapshots:
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
-
-  istanbul-reports@3.1.7:
-    dependencies:
-      html-escaper: 2.0.2
-      istanbul-lib-report: 3.0.1
 
   istanbul-reports@3.2.0:
     dependencies:


### PR DESCRIPTION
`latest` is a curse and can easily drift, or change wildly on lockfile regeneration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned the code coverage tooling to a stable compatible version for more consistent development and testing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->